### PR TITLE
Github workflow to test that `remotes::install_local()` works

### DIFF
--- a/.github/workflows/github-actions-install.yml
+++ b/.github/workflows/github-actions-install.yml
@@ -3,6 +3,9 @@ on: [push]
 jobs:
   Can-it-be-installed:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        R: [ '3.5.3', '3.6.1' , '4.1.0', 'release']    
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -19,6 +22,8 @@ jobs:
       - name: Install curl
         run: sudo apt-get install libcurl4-openssl-dev
       - uses: r-lib/actions/setup-r@v1
+        with:
+          r-version: ${{ matrix.config.r }}      
       - name: Install devtools
         run: |
           install.packages(c("devtools"))

--- a/.github/workflows/github-actions-install.yml
+++ b/.github/workflows/github-actions-install.yml
@@ -10,7 +10,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
+      - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event"
       - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
       - run: echo "⚙ This job uses R version ${{ matrix.R }} "
       - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."

--- a/.github/workflows/github-actions-install.yml
+++ b/.github/workflows/github-actions-install.yml
@@ -1,10 +1,11 @@
 name: Installable
 on: [push]
 jobs:
-  Can-it-be-installed-on-linux:
-    runs-on: ubuntu-latest
+  Can-it-be-installed:
+    runs-on: ${{ matrix.OS }}
     strategy:
       matrix:
+        OS: ['macOS-latest', 'windows-latest', 'ubuntu-latest']      
         R: [ '4.0.0', 'release']    
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
@@ -17,55 +18,38 @@ jobs:
         uses: actions/checkout@v2
       - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
       - run: echo "🖥️ The workflow is now ready to test your code on the runner."
-      - name: List files in the repository
-        run: |
-          ls ${{ github.workspace }}
       - name: Install curl
+        if: runner.os == 'Linux'      
         run: sudo apt-get install libcurl4-openssl-dev
       - uses: r-lib/actions/setup-r@v1
         with:
           r-version: ${{ matrix.R }}      
-      - name: Install devtools
+
+      - name: Query dependencies
         run: |
-          install.packages(c("devtools"))
+          install.packages('remotes')
+          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
+          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
         shell: Rscript {0}
-      - name: Install OlinkAnalyze
-        run: |
-          devtools::install("OlinkAnalyze")
-        shell: Rscript {0}
-      - name: Test if OlinkAnalyze can be loaded
-        run: |
-          library("OlinkAnalyze")
-          sessionInfo()
-        shell: Rscript {0}
-  Can-it-be-installed-win-and-mac:
-    runs-on: ${{ matrix.OS }}
-    strategy:
-      matrix:
-        OS: ['macOS-latest', 'windows-latest']
-        R: [ '4.0.0', 'release']    
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
-      - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
-      - run: echo "⚙ This job uses R version ${{ matrix.R }} "
-      - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
-      - name: Check out repository code
-        uses: actions/checkout@v2
-      - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
-      - run: echo "🖥️ The workflow is now ready to test your code on the runner."
-      - uses: r-lib/actions/setup-r@v1
+
+      - name: Cache R packages
+        if: runner.os != 'Windows'
+        uses: actions/cache@v2
         with:
-          r-version: ${{ matrix.R }}      
+          path: ${{ env.R_LIBS_USER }}
+          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
+          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+
       - name: Install devtools
         run: |
           install.packages(c("devtools"))
         shell: Rscript {0}
+
       - name: Install OlinkAnalyze
         run: |
           devtools::install("OlinkAnalyze")
         shell: Rscript {0}
+
       - name: Test if OlinkAnalyze can be loaded
         run: |
           library("OlinkAnalyze")

--- a/.github/workflows/github-actions-install.yml
+++ b/.github/workflows/github-actions-install.yml
@@ -38,43 +38,12 @@ jobs:
           library("OlinkAnalyze")
           sessionInfo()
         shell: Rscript {0}
-  Can-it-be-installed-on-windows:
-    runs-on: windows-latest
+  Can-it-be-installed-win-and-mac:
+    runs-on: ${{ matrix.OS }}
     strategy:
       matrix:
-        R: [ '4.0.0', 'release']    
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
-      - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
-      - run: echo "⚙ This job uses R version ${{ matrix.R }} "
-      - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
-      - name: Check out repository code
-        uses: actions/checkout@v2
-      - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
-      - run: echo "🖥️ The workflow is now ready to test your code on the runner."
-      - uses: r-lib/actions/setup-r@v1
-        with:
-          r-version: ${{ matrix.R }}      
-      - name: Install devtools
-        run: |
-          install.packages(c("devtools"))
-        shell: Rscript {0}
-      - name: Install OlinkAnalyze
-        run: |
-          devtools::install("OlinkAnalyze")
-        shell: Rscript {0}
-      - name: Test if OlinkAnalyze can be loaded
-        run: |
-          library("OlinkAnalyze")
-          sessionInfo()
-        shell: Rscript {0}
-  Can-it-be-installed-on-mac:
-    runs-on: macOS-latest
-    strategy:
-      matrix:
-        R: [ '4.0.0', 'release']    
+        OS: ['macOS-latest', 'windows-latest']
+        R: [ '3.5.3', '4.0.0', 'release']    
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/.github/workflows/github-actions-install.yml
+++ b/.github/workflows/github-actions-install.yml
@@ -5,13 +5,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        R: [ '3.5.3', 'release']    
+        R: [ '4.0.0', 'release']    
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
       - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
-      - run: echo "This job uses R version ${{ matrix.R }} "
+      - run: echo "⚙ This job uses R version ${{ matrix.R }} "
       - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
       - name: Check out repository code
         uses: actions/checkout@v2

--- a/.github/workflows/github-actions-install.yml
+++ b/.github/workflows/github-actions-install.yml
@@ -29,6 +29,6 @@ jobs:
         shell: Rscript {0}
       - name: Test if OlinkAnalyze can be loaded
         run: |
-          library("olinkr")
+          library("OlinkAnalyze")
           sessionInfo()
         shell: Rscript {0}

--- a/.github/workflows/github-actions-install.yml
+++ b/.github/workflows/github-actions-install.yml
@@ -4,6 +4,7 @@ jobs:
   Can-it-be-installed:
     runs-on: ${{ matrix.OS }}
     strategy:
+      fail-fast: true
       matrix:
         OS: ['macOS-latest', 'windows-latest', 'ubuntu-latest']      
         R: [ '4.0.0', 'release']    
@@ -42,7 +43,7 @@ jobs:
 
       - name: Install OlinkAnalyze
         run: |
-          remotes::install("OlinkAnalyze")
+          remotes::install_local("OlinkAnalyze")
         shell: Rscript {0}
 
       - name: Test if OlinkAnalyze can be loaded

--- a/.github/workflows/github-actions-install.yml
+++ b/.github/workflows/github-actions-install.yml
@@ -5,12 +5,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        R: [ '3.5.3', '3.6.1' , 'release']    
+        R: [ '3.5.3', 'release']    
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
       - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
+      - run: echo "This job uses R version ${{ matrix.R }} "
       - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
       - name: Check out repository code
         uses: actions/checkout@v2
@@ -23,7 +24,7 @@ jobs:
         run: sudo apt-get install libcurl4-openssl-dev
       - uses: r-lib/actions/setup-r@v1
         with:
-          r-version: ${{ matrix.config.R }}      
+          r-version: ${{ matrix.R }}      
       - name: Install devtools
         run: |
           install.packages(c("devtools"))

--- a/.github/workflows/github-actions-install.yml
+++ b/.github/workflows/github-actions-install.yml
@@ -70,3 +70,35 @@ jobs:
           library("OlinkAnalyze")
           sessionInfo()
         shell: Rscript {0}
+  Can-it-be-installed-on-mac:
+    runs-on: macOS-latest
+    strategy:
+      matrix:
+        R: [ '4.0.0', 'release']    
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
+      - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
+      - run: echo "⚙ This job uses R version ${{ matrix.R }} "
+      - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
+      - run: echo "🖥️ The workflow is now ready to test your code on the runner."
+      - uses: r-lib/actions/setup-r@v1
+        with:
+          r-version: ${{ matrix.R }}      
+      - name: Install devtools
+        run: |
+          install.packages(c("devtools"))
+        shell: Rscript {0}
+      - name: Install OlinkAnalyze
+        run: |
+          devtools::install("OlinkAnalyze")
+        shell: Rscript {0}
+      - name: Test if OlinkAnalyze can be loaded
+        run: |
+          library("OlinkAnalyze")
+          sessionInfo()
+        shell: Rscript {0}

--- a/.github/workflows/github-actions-install.yml
+++ b/.github/workflows/github-actions-install.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Query dependencies
         run: |
           install.packages('remotes')
-          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
+          saveRDS(remotes::dev_package_deps(pkgdir = "OlinkAnalyze", dependencies = TRUE), ".github/depends.Rds", version = 2)
           writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
         shell: Rscript {0}
 

--- a/.github/workflows/github-actions-install.yml
+++ b/.github/workflows/github-actions-install.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        R: [ '3.5.3', '3.6.1' , '4.1.0', 'release']    
+        R: [ '3.5.3', '3.6.1' , 'release']    
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -23,7 +23,7 @@ jobs:
         run: sudo apt-get install libcurl4-openssl-dev
       - uses: r-lib/actions/setup-r@v1
         with:
-          r-version: ${{ matrix.config.r }}      
+          r-version: ${{ matrix.config.R }}      
       - name: Install devtools
         run: |
           install.packages(c("devtools"))

--- a/.github/workflows/github-actions-install.yml
+++ b/.github/workflows/github-actions-install.yml
@@ -1,0 +1,34 @@
+name: Installable
+on: [push]
+jobs:
+  Can-it-be-installed:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
+      - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
+      - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
+      - run: echo "🖥️ The workflow is now ready to test your code on the runner."
+      - name: List files in the repository
+        run: |
+          ls ${{ github.workspace }}
+      - name: Install curl
+        run: sudo apt-get install libcurl4-openssl-dev
+      - uses: r-lib/actions/setup-r@v1
+      - name: Install devtools
+        run: |
+          install.packages(c("devtools"))
+        shell: Rscript {0}
+      - name: Install OlinkAnalyze
+        run: |
+          devtools::install("OlinkAnalyze")
+        shell: Rscript {0}
+      - name: Test if OlinkAnalyze can be loaded
+        run: |
+          library("olinkr")
+          sessionInfo()
+        shell: Rscript {0}

--- a/.github/workflows/github-actions-install.yml
+++ b/.github/workflows/github-actions-install.yml
@@ -1,7 +1,7 @@
 name: Installable
 on: [push]
 jobs:
-  Can-it-be-installed:
+  Can-it-be-installed-on-linux:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -22,6 +22,38 @@ jobs:
           ls ${{ github.workspace }}
       - name: Install curl
         run: sudo apt-get install libcurl4-openssl-dev
+      - uses: r-lib/actions/setup-r@v1
+        with:
+          r-version: ${{ matrix.R }}      
+      - name: Install devtools
+        run: |
+          install.packages(c("devtools"))
+        shell: Rscript {0}
+      - name: Install OlinkAnalyze
+        run: |
+          devtools::install("OlinkAnalyze")
+        shell: Rscript {0}
+      - name: Test if OlinkAnalyze can be loaded
+        run: |
+          library("OlinkAnalyze")
+          sessionInfo()
+        shell: Rscript {0}
+  Can-it-be-installed-on-windows:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        R: [ '4.0.0', 'release']    
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
+      - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
+      - run: echo "⚙ This job uses R version ${{ matrix.R }} "
+      - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
+      - run: echo "🖥️ The workflow is now ready to test your code on the runner."
       - uses: r-lib/actions/setup-r@v1
         with:
           r-version: ${{ matrix.R }}      

--- a/.github/workflows/github-actions-install.yml
+++ b/.github/workflows/github-actions-install.yml
@@ -40,14 +40,9 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
           restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
 
-      - name: Install devtools
-        run: |
-          install.packages(c("devtools"))
-        shell: Rscript {0}
-
       - name: Install OlinkAnalyze
         run: |
-          devtools::install("OlinkAnalyze")
+          remotes::install("OlinkAnalyze")
         shell: Rscript {0}
 
       - name: Test if OlinkAnalyze can be loaded

--- a/.github/workflows/github-actions-install.yml
+++ b/.github/workflows/github-actions-install.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       matrix:
         OS: ['macOS-latest', 'windows-latest']
-        R: [ '3.5.3', '4.0.0', 'release']    
+        R: [ '4.0.0', 'release']    
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:


### PR DESCRIPTION
This code will test if the package is installable using `remotes::install_local()` which is very much parallel to the `devtools::install_github()` method we currently recommend in the readme.

Tests are run on Windows / Ubuntu / Mac and with R version 4.0.0 and the most recent release.

The runtime of the workflow is rather long since many packages need to be installed. I implemented caching on Mac and Linux however.

Best time to merge this PR might be after merging the function specific reformatting branches. 

Also: I'm sorry for the messy commit history, it was a bumpy ride to make sure the github engines liked my code... Might be good to squash the commits before merge...