### PR TITLE
Test that a PCA plot with example data looks as expected

### DIFF
--- a/OlinkAnalyze/DESCRIPTION
+++ b/OlinkAnalyze/DESCRIPTION
@@ -8,7 +8,11 @@ Encoding: UTF-8
 LazyData: true
 Depends: broom, car, emmeans, ggfortify, ggrepel, lmerTest, openxlsx, stringr, tidyverse, readxl , RColorBrewer, dplyr, scales, tidyr
 RoxygenNote: 7.1.1
-Suggests: knitr, rmarkdown
+Suggests: 
+    knitr,
+    rmarkdown,
+    testthat (>= 3.0.0),
+    vdiffr
 License: GPL-3 | file LICENSE
 Maintainer: DS at Olink <biostattools@olink.com>
 VignetteBuilder: knitr
@@ -22,3 +26,4 @@ Imports:
     tibble,
     tidyselect,
     utils
+Config/testthat/edition: 3

--- a/OlinkAnalyze/R/pca_plot.R
+++ b/OlinkAnalyze/R/pca_plot.R
@@ -328,14 +328,14 @@ olink_pca_plot <- function (df,
     pca_plot <- pca_plot +
       ggplot2::geom_text(ggplot2::aes(label = observation_names, color = observation_colors), size = 3) +
       ggplot2::labs(color = color_g) +
-      ggplot2::guides(size = FALSE)
+      ggplot2::guides(size = "none")
 
   }else{
 
     pca_plot <- pca_plot +
       ggplot2::geom_point(ggplot2::aes(color = observation_colors), size = 2.5) +
       ggplot2::labs(color = color_g) +
-      ggplot2::guides(size = FALSE)
+      ggplot2::guides(size = "none")
 
   }
 

--- a/OlinkAnalyze/tests/testthat.R
+++ b/OlinkAnalyze/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(OlinkAnalyze)
+
+test_check("OlinkAnalyze")

--- a/OlinkAnalyze/tests/testthat/_snaps/pca_plot/pca-plot.svg
+++ b/OlinkAnalyze/tests/testthat/_snaps/pca_plot/pca-plot.svg
@@ -1,0 +1,214 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpNDMuMDZ8NjI5LjAyfDIyLjc4fDU0NS4xMQ=='>
+    <rect x='43.06' y='22.78' width='585.96' height='522.33' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDMuMDZ8NjI5LjAyfDIyLjc4fDU0NS4xMQ==)'>
+<rect x='43.06' y='22.78' width='585.96' height='522.33' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='465.25' cy='264.58' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='400.85' cy='234.27' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='406.87' cy='223.12' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='403.78' cy='219.03' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='430.32' cy='171.15' r='3.02' style='stroke-width: 0.71; stroke: #FE1F04; fill: #FE1F04;' />
+<circle cx='466.14' cy='173.81' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='452.33' cy='170.16' r='3.02' style='stroke-width: 0.71; stroke: #FE1F04; fill: #FE1F04;' />
+<circle cx='168.81' cy='195.76' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='113.01' cy='198.16' r='3.02' style='stroke-width: 0.71; stroke: #FE1F04; fill: #FE1F04;' />
+<circle cx='131.69' cy='211.11' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='371.14' cy='281.32' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='484.90' cy='253.91' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='371.42' cy='286.70' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='405.89' cy='275.50' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='286.75' cy='232.06' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='300.74' cy='213.99' r='3.02' style='stroke-width: 0.71; stroke: #FE1F04; fill: #FE1F04;' />
+<circle cx='290.67' cy='217.51' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='495.19' cy='196.78' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='493.43' cy='201.50' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='452.37' cy='160.44' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='308.69' cy='247.71' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='228.31' cy='274.45' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='454.70' cy='261.31' r='3.02' style='stroke-width: 0.71; stroke: #FE1F04; fill: #FE1F04;' />
+<circle cx='203.80' cy='231.45' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='263.48' cy='164.56' r='3.02' style='stroke-width: 0.71; stroke: #FE1F04; fill: #FE1F04;' />
+<circle cx='225.68' cy='138.91' r='3.02' style='stroke-width: 0.71; stroke: #FE1F04; fill: #FE1F04;' />
+<circle cx='245.95' cy='143.99' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='395.82' cy='229.21' r='3.02' style='stroke-width: 0.71; stroke: #FE1F04; fill: #FE1F04;' />
+<circle cx='388.34' cy='222.68' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='355.18' cy='212.43' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='602.38' cy='181.08' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='560.80' cy='201.51' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='574.78' cy='164.95' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='360.08' cy='202.69' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='406.82' cy='152.75' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='392.20' cy='173.77' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='448.68' cy='149.94' r='3.02' style='stroke-width: 0.71; stroke: #FE1F04; fill: #FE1F04;' />
+<circle cx='250.50' cy='174.42' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='199.92' cy='156.75' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='223.29' cy='142.01' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='459.12' cy='138.24' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='429.11' cy='140.14' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='428.64' cy='148.51' r='3.02' style='stroke-width: 0.71; stroke: #FE1F04; fill: #FE1F04;' />
+<circle cx='354.25' cy='196.87' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='384.99' cy='183.27' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='358.68' cy='205.23' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='318.91' cy='198.72' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='212.67' cy='67.52' r='3.02' style='stroke-width: 0.71; stroke: #FE1F04; fill: #FE1F04;' />
+<circle cx='216.53' cy='62.58' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='277.11' cy='46.53' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='249.31' cy='202.48' r='3.02' style='stroke-width: 0.71; stroke: #FE1F04; fill: #FE1F04;' />
+<circle cx='278.24' cy='221.70' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='279.89' cy='202.19' r='3.02' style='stroke-width: 0.71; stroke: #FE1F04; fill: #FE1F04;' />
+<circle cx='492.91' cy='72.85' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='475.85' cy='79.59' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='402.00' cy='206.42' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='485.60' cy='87.13' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='385.13' cy='118.50' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='388.32' cy='103.83' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='350.02' cy='93.64' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='409.02' cy='207.11' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='395.63' cy='185.72' r='3.02' style='stroke-width: 0.71; stroke: #FE1F04; fill: #FE1F04;' />
+<circle cx='345.58' cy='213.93' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='243.12' cy='205.78' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='171.19' cy='220.12' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='174.91' cy='193.39' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='404.21' cy='235.59' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='366.62' cy='220.03' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='358.80' cy='212.06' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='347.00' cy='199.09' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='266.52' cy='207.03' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='341.27' cy='194.71' r='3.02' style='stroke-width: 0.71; stroke: #FE1F04; fill: #FE1F04;' />
+<circle cx='351.76' cy='188.97' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='391.92' cy='203.21' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='365.70' cy='213.93' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='376.52' cy='241.24' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='407.92' cy='262.50' r='3.02' style='stroke-width: 0.71; stroke: #FE1F04; fill: #FE1F04;' />
+<circle cx='369.90' cy='185.72' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='366.14' cy='190.38' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='392.11' cy='226.51' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='375.75' cy='205.91' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='383.37' cy='233.88' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='283.94' cy='157.48' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='259.28' cy='164.48' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='350.55' cy='178.25' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='250.67' cy='196.32' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='172.23' cy='190.48' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='180.58' cy='205.02' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='188.03' cy='171.86' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='237.20' cy='126.72' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='280.67' cy='134.29' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='283.30' cy='125.94' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='511.76' cy='80.56' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='470.91' cy='90.28' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='468.39' cy='94.29' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='483.30' cy='172.53' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='523.20' cy='192.54' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='511.50' cy='166.71' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='320.33' cy='221.25' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='69.70' cy='222.19' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='348.39' cy='209.96' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='364.40' cy='197.41' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='325.41' cy='282.38' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='259.46' cy='255.24' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='256.31' cy='255.60' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='157.29' cy='172.45' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='160.57' cy='182.27' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='146.58' cy='149.34' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='325.61' cy='244.18' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='293.65' cy='208.57' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='96.07' cy='192.99' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='288.07' cy='209.58' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='249.41' cy='197.11' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='325.80' cy='205.26' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='318.10' cy='209.31' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='493.07' cy='118.51' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='554.65' cy='143.01' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='538.38' cy='109.43' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='169.10' cy='133.42' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='88.59' cy='156.31' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='172.72' cy='127.19' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='214.71' cy='203.50' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='278.05' cy='200.41' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='278.16' cy='196.88' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='238.89' cy='202.23' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='116.39' cy='184.13' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='106.82' cy='213.88' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='81.99' cy='172.86' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='322.82' cy='207.63' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='261.24' cy='223.92' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='269.20' cy='218.58' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='323.42' cy='199.03' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='172.44' cy='233.79' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='259.61' cy='205.22' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='347.89' cy='193.17' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='280.26' cy='203.31' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='302.34' cy='202.99' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='259.98' cy='208.36' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='436.18' cy='357.77' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='441.09' cy='521.37' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='421.74' cy='337.13' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='266.18' cy='218.91' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='245.69' cy='236.73' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='192.41' cy='225.23' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='194.39' cy='218.29' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='300.58' cy='207.44' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='192.56' cy='217.43' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='235.65' cy='196.41' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='457.52' cy='198.50' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='452.20' cy='210.77' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='497.13' cy='209.41' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='306.43' cy='79.34' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='267.58' cy='104.92' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='216.15' cy='92.66' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='340.98' cy='208.41' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<circle cx='370.60' cy='219.02' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<polyline points='43.06,545.11 43.06,22.78 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<text x='38.13' y='374.70' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='20.06px' lengthAdjust='spacingAndGlyphs'>-0.25</text>
+<text x='38.13' y='195.40' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>0.00</text>
+<polyline points='40.32,371.67 43.06,371.67 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='40.32,192.38 43.06,192.38 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='43.06,545.11 629.02,545.11 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='184.20,547.85 184.20,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='327.18,547.85 327.18,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='470.15,547.85 470.15,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='613.13,547.85 613.13,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='184.20' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='15.16px' lengthAdjust='spacingAndGlyphs'>-0.1</text>
+<text x='327.18' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='470.15' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.1</text>
+<text x='613.13' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.2</text>
+<text x='336.04' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='62.98px' lengthAdjust='spacingAndGlyphs'>PC1 (1.84%)</text>
+<text transform='translate(13.05,283.95) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='62.98px' lengthAdjust='spacingAndGlyphs'>PC2 (1.69%)</text>
+<rect x='639.98' y='253.52' width='74.54' height='60.85' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='645.46' y='267.71' style='font-size: 11.00px; font-family: sans;' textLength='63.58px' lengthAdjust='spacingAndGlyphs'>QC_Warning</text>
+<rect x='645.46' y='274.33' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='654.10' cy='282.97' r='3.02' style='stroke-width: 0.71; stroke: #00C7E1; fill: #00C7E1;' />
+<rect x='645.46' y='291.61' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='654.10' cy='300.25' r='3.02' style='stroke-width: 0.71; stroke: #FE1F04; fill: #FE1F04;' />
+<text x='668.22' y='286.00' style='font-size: 8.80px; font-family: sans;' textLength='19.57px' lengthAdjust='spacingAndGlyphs'>Pass</text>
+<text x='668.22' y='303.28' style='font-size: 8.80px; font-family: sans;' textLength='32.77px' lengthAdjust='spacingAndGlyphs'>Warning</text>
+<text x='43.06' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='52.10px' lengthAdjust='spacingAndGlyphs'>PCA plot</text>
+</g>
+</svg>

--- a/OlinkAnalyze/tests/testthat/test-pca_plot.R
+++ b/OlinkAnalyze/tests/testthat/test-pca_plot.R
@@ -2,3 +2,8 @@ test_that("plot output", {
   p <- olink_pca_plot(npx_data1 %>% filter(!str_detect(SampleID,"CONTROL")))
   vdiffr::expect_doppelganger("PCA plot", p)
 })
+
+
+test_that("No warning", {
+  expect_warning(olink_pca_plot(npx_data1 %>% filter(!str_detect(SampleID,"CONTROL"))), regexp = NA)
+})

--- a/OlinkAnalyze/tests/testthat/test-pca_plot.R
+++ b/OlinkAnalyze/tests/testthat/test-pca_plot.R
@@ -1,0 +1,4 @@
+test_that("plot output", {
+  p <- olink_pca_plot(npx_data1 %>% filter(!str_detect(SampleID,"CONTROL")))
+  vdiffr::expect_doppelganger("PCA plot", p)
+})


### PR DESCRIPTION
Using `testthat` and `vdiffr` to ensure that a PCA plot based on example data is identical to the expectation.

to run the tests independent from `devtools::check()` use `devtools::test()`