### PR TITLE
Feature: Use Swedish Gothic Thin for plot labels if available

### DIFF
--- a/OlinkAnalyze/DESCRIPTION
+++ b/OlinkAnalyze/DESCRIPTION
@@ -8,8 +8,34 @@ Depends: R (>= 4.0.0)
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.1.1
-Suggests: knitr, rmarkdown
+Suggests: 
+    extrafont,
+    knitr,
+    rmarkdown
 License: GPL-3 | file LICENSE
 Maintainer: DS at Olink <biostattools@olink.com>
 VignetteBuilder: knitr
-Imports: dplyr, emmeans, forcats, generics, ggplot2, ggrepel, grDevices, grid, lme4, lmerTest, magrittr, methods, readxl, rlang, stats, stringr, tibble, tidyr, tidyselect, tools, utils
+Imports: 
+    car,
+    broom,
+    dplyr,
+    emmeans,
+    forcats,
+    generics,
+    ggplot2,
+    ggrepel,
+    grDevices,
+    grid,
+    lme4,
+    lmerTest,
+    magrittr,
+    methods,
+    readxl,
+    rlang,
+    stats,
+    stringr,
+    tibble,
+    tidyr,
+    tidyselect,
+    tools,
+    utils

--- a/OlinkAnalyze/R/Olink_theme.R
+++ b/OlinkAnalyze/R/Olink_theme.R
@@ -1,17 +1,48 @@
 #' Function to set plot theme
 #'
 #' This function sets a coherent plot theme for functions.
+#'
+#' @param font Font family to use for text elements. Depends on extrafont package.
+#'
 #' @export
 #' @importFrom ggplot2 theme element_blank element_line element_rect element_text
-
-set_plot_theme <- function() {
+#'
+#' @examples
+#' library(ggplot2)
+#'
+#' ggplot(mtcars, aes(x = wt, y = mpg, color = as.factor(cyl))) +
+#'   geom_point(size = 4) +
+#'   set_plot_theme()
+#'
+#' ggplot(mtcars, aes(x = wt, y = mpg, color = as.factor(cyl))) +
+#'   geom_point(size = 4) +
+#'   set_plot_theme(font = "")
+#'
+#'
+set_plot_theme <- function(font = "Swedish Gothic Thin") {
+  if (requireNamespace("extrafont", quietly = TRUE) & font %in% extrafont::fonts()) {
+    extrafont::loadfonts(quiet = TRUE, device = "win")
+    extrafont::loadfonts(quiet = TRUE, device = "pdf")
+    usefont <- font
+  } else {
+    usefont <- ""
+  }
 
   olink_theme <- ggplot2::theme_bw() +
-    ggplot2::theme(panel.grid.major = ggplot2::element_blank(),
-                   panel.grid.minor = ggplot2::element_blank()) +
-    ggplot2::theme(panel.border = ggplot2::element_blank(),
-                   axis.line = ggplot2::element_line(size = 0.5)) +
-    ggplot2::theme(strip.background = ggplot2::element_rect(fill = "white"),
-          strip.text = ggplot2::element_text(size = 8),
-          strip.text.x = ggplot2::element_text(size = 13))
+    ggplot2::theme(
+      panel.grid.major = ggplot2::element_blank(),
+      panel.grid.minor = ggplot2::element_blank()
+    ) +
+    ggplot2::theme(
+      panel.border = ggplot2::element_blank(),
+      axis.line = ggplot2::element_line(size = 0.5)
+    ) +
+    ggplot2::theme(
+      strip.background = ggplot2::element_rect(fill = "white"),
+      strip.text = ggplot2::element_text(size = 8),
+      strip.text.x = ggplot2::element_text(size = 13)
+    ) +
+    ggplot2::theme(
+      text = ggplot2::element_text(family = usefont, color = "#737373", size = 12)
+    )
 }

--- a/OlinkAnalyze/R/Olink_theme.R
+++ b/OlinkAnalyze/R/Olink_theme.R
@@ -20,12 +20,15 @@
 #'
 #'
 set_plot_theme <- function(font = "Swedish Gothic Thin") {
-  if (requireNamespace("extrafont", quietly = TRUE) & font %in% extrafont::fonts()) {
-    extrafont::loadfonts(quiet = TRUE, device = "win")
-    extrafont::loadfonts(quiet = TRUE, device = "pdf")
-    usefont <- font
-  } else {
-    usefont <- ""
+
+  usefont <- ""
+
+  if (requireNamespace("extrafont", quietly = TRUE)) {
+    if(font %in% extrafont::fonts()){
+      extrafont::loadfonts(quiet = TRUE, device = "win")
+      extrafont::loadfonts(quiet = TRUE, device = "pdf")
+      usefont <- font
+    }
   }
 
   olink_theme <- ggplot2::theme_bw() +

--- a/OlinkAnalyze/man/set_plot_theme.Rd
+++ b/OlinkAnalyze/man/set_plot_theme.Rd
@@ -4,8 +4,24 @@
 \alias{set_plot_theme}
 \title{Function to set plot theme}
 \usage{
-set_plot_theme()
+set_plot_theme(font = "Swedish Gothic Thin")
+}
+\arguments{
+\item{font}{Font family to use for text elements. Depends on extrafont package.}
 }
 \description{
 This function sets a coherent plot theme for functions.
+}
+\examples{
+library(ggplot2)
+
+ggplot(mtcars, aes(x = wt, y = mpg, color = as.factor(cyl))) +
+  geom_point(size = 4) +
+  set_plot_theme()
+
+ggplot(mtcars, aes(x = wt, y = mpg, color = as.factor(cyl))) +
+  geom_point(size = 4) +
+  set_plot_theme(font = "")
+
+
 }


### PR DESCRIPTION
Modified the `set_plot_theme()` function to accept a `font` parameter (default: "Swedish Gothic Thin") that is used for any text in the plots.

If {extrafont} or the requested font family are not available the ggplot default font is used without any error message.