### PR TITLE
multiple adjustment in posthoc fix

### DIFF
--- a/OlinkAnalyze/DESCRIPTION
+++ b/OlinkAnalyze/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: OlinkAnalyze
 Type: Package
 Title: Package to Facilitate NPX Data Handling
-Version: 1.2.5
+Version: 1.2.6
 Author: DS at Olink (given="Data", family="Science", email = "biostattools@olink.com", role = c("aut", "cre"))
 Description: Package for working with Olink NPX data, primarily exported from Olink NPX Manager. 
 Encoding: UTF-8

--- a/OlinkAnalyze/R/Olink_anova.R
+++ b/OlinkAnalyze/R/Olink_anova.R
@@ -287,7 +287,7 @@ olink_anova <- function(df,
 #' Covariates to include. Takes ':'/'*' notation. Crossed analysis will not be inferred from main effects.
 #' @param outcome Character. The dependent variable. Default: NPX.
 #' @param effect Term on which to perform post-hoc. Character vector. Must be subset of or identical to variable.
-#' @param mean_return Boolean. If true, returns the mean of each factor level rather than the difference in means (default). Note that no p-value is returned for mean_return = T.
+#' @param mean_return Boolean. If true, returns the mean of each factor level rather than the difference in means (default). Note that no p-value is returned for mean_return = T and no adjustment is performed.
 #' @param verbose Boolean. Default: True. If information about removed samples, factor conversion and final model formula is to be printed to the console.
 #'
 #' @return Tibble of posthoc tests for specified effect, arranged by ascending adjusted p-values.
@@ -421,15 +421,13 @@ olink_anova_posthoc <- function(df,
       message(paste("Means estimated for each assay from ANOVA model: ",formula_string))
     }
 
-
-
     anova_posthoc_results <- df %>%
       filter(OlinkID %in% olinkid_list) %>%
       mutate(OlinkID = factor(OlinkID, levels = olinkid_list)) %>%
       group_by(Assay, OlinkID, UniProt, Panel) %>%
-      do(data.frame(summary(emmeans(lm(as.formula(formula_string),data=.),
+      do(data.frame(emmeans(lm(as.formula(formula_string),data=.),
                                     specs=as.formula(paste0("pairwise~", paste(effect,collapse="+"))),
-                                    cov.reduce = function(x) round(c(mean(x),mean(x)+sd(x)),4)),
+                                    cov.reduce = function(x) round(c(mean(x),mean(x)+sd(x)),4),
                             infer=c(T,T),
                             adjust="tukey")[[c("contrasts","emmeans")[1+as.numeric(mean_return)]]],
                     stringsAsFactors=F)) %>%

--- a/OlinkAnalyze/R/linear_mixed_model.R
+++ b/OlinkAnalyze/R/linear_mixed_model.R
@@ -303,7 +303,7 @@ single_lmer <- function(data, formula_string){
 #' @param random Single character value or character array.
 #' @param covariates Single character value or character array. Default: NULL.
 #' Covariates to include. Takes ':'/'*' notation. Crossed analysis will not be inferred from main effects.
-#' @param mean_return Boolean. If true, returns the mean of each factor level rather than the difference in means (default). Note that no p-value is returned for mean_return = T.
+#' @param mean_return Boolean. If true, returns the mean of each factor level rather than the difference in means (default). Note that no p-value is returned for mean_return = T and no adjustment is performed.
 #' @param verbose Boolean. Deafult: True. If information about removed samples, factor conversion and final model formula is to be printed to the console.
 #' @param variable Single character value or character array.
 #' Variable(s) to test. If length > 1, the included variable names will be used in crossed analyses .
@@ -479,10 +479,10 @@ single_posthoc <- function(data, formula_string, effect, mean_return){
   the_model <- emmeans::emmeans(single_lmer(data, formula_string),
                                 specs=as.formula(paste0("pairwise~", paste(effect,collapse="+"))),
                                 cov.reduce = function(x) round(c(mean(x),mean(x)+sd(x)),4),
-                                lmer.df="satterthwaite")
-  the_model <- summary(the_model,infer=c(T,T),
-                       adjust="tukey")
-
+                                lmer.df="satterthwaite",
+                                infer = c(T,T), 
+                                adjust = 'tukey')
+  
   if(mean_return){
     tmp <- unique(unlist(strsplit(effect,":")))
     return(as_tibble(the_model$emmeans) %>%

--- a/OlinkAnalyze/man/olink_anova_posthoc.Rd
+++ b/OlinkAnalyze/man/olink_anova_posthoc.Rd
@@ -31,7 +31,7 @@ Covariates to include. Takes ':'/'*' notation. Crossed analysis will not be infe
 
 \item{effect}{Term on which to perform post-hoc. Character vector. Must be subset of or identical to variable.}
 
-\item{mean_return}{Boolean. If true, returns the mean of each factor level rather than the difference in means (default). Note that no p-value is returned for mean_return = T.}
+\item{mean_return}{Boolean. If true, returns the mean of each factor level rather than the difference in means (default). Note that no p-value is returned for mean_return = T and no adjustment is performed.}
 
 \item{verbose}{Boolean. Default: True. If information about removed samples, factor conversion and final model formula is to be printed to the console.}
 }

--- a/OlinkAnalyze/man/olink_lmer_posthoc.Rd
+++ b/OlinkAnalyze/man/olink_lmer_posthoc.Rd
@@ -34,7 +34,7 @@ Also takes ':'/'*' notation.}
 \item{covariates}{Single character value or character array. Default: NULL.
 Covariates to include. Takes ':'/'*' notation. Crossed analysis will not be inferred from main effects.}
 
-\item{mean_return}{Boolean. If true, returns the mean of each factor level rather than the difference in means (default). Note that no p-value is returned for mean_return = T.}
+\item{mean_return}{Boolean. If true, returns the mean of each factor level rather than the difference in means (default). Note that no p-value is returned for mean_return = T and no adjustment is performed.}
 
 \item{verbose}{Boolean. Deafult: True. If information about removed samples, factor conversion and final model formula is to be printed to the console.}
 }


### PR DESCRIPTION
Fix for summary casting 'tukey' to 'sidak' adjustment warning in posthoc functions. New functionality is pairwise tests with Tukey adjustment (as before) and mean return with none. 
Update of function description and package version.