### PR TITLE
More details from unit tests in CI log

### DIFF
--- a/.github/workflows/R-CMD-check-full.yaml
+++ b/.github/workflows/R-CMD-check-full.yaml
@@ -85,6 +85,14 @@ jobs:
         run: find check -name 'testthat.Rout*' -exec cat '{}' \; || true
         shell: bash
 
+      - name: Rerun of tests with detailed output
+        env:
+          _R_CHECK_CRAN_INCOMING_REMOTE_: false
+        run: |
+          testthat::test_local(path = "OlinkAnalyze", reporter = c("location","summary"))
+        shell: Rscript {0}
+
+
       - name: Upload check results
         if: failure()
         uses: actions/upload-artifact@main

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -67,6 +67,15 @@ jobs:
           rcmdcheck::rcmdcheck(path = "OlinkAnalyze", args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")
         shell: Rscript {0}
 
+
+      - name: Rerun of tests with detailed output
+        env:
+          _R_CHECK_CRAN_INCOMING_REMOTE_: false
+        run: |
+          testthat::test_local(path = "OlinkAnalyze", reporter = c("location","summary"))
+        shell: Rscript {0}
+
+
       - name: Upload check results
         if: failure()
         uses: actions/upload-artifact@main


### PR DESCRIPTION
Just adding another round of `{testthat}` after the `R CMD check` to get a detailed output of test results in the log for the github workflow.