### PR TITLE
Randomized order output bridge selector

### DIFF
--- a/OlinkAnalyze/DESCRIPTION
+++ b/OlinkAnalyze/DESCRIPTION
@@ -7,7 +7,7 @@ Description: Package for working with Olink NPX data, primarily exported from Ol
 Depends: R (>= 3.6.0)
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 Suggests: 
     extrafont,
     knitr,

--- a/OlinkAnalyze/R/Olink_bridgeselector.R
+++ b/OlinkAnalyze/R/Olink_bridgeselector.R
@@ -94,7 +94,9 @@ olink_bridgeselector<-function(df, sampleMissingFreq, n, warning_string = NULL){
   Bridgesamples <- floor(seq(1,nrow(df_2),length.out = n+2)[c(-1, -(n+2))])
 
   SelectedBridges <- df_2 %>%
-    dplyr::filter(Order %in% Bridgesamples)
+    dplyr::filter(Order %in% Bridgesamples) %>%
+    dplyr::slice_sample(n = nrow(.)) %>%
+    dplyr::select(-Order)
 
   return(SelectedBridges)
 }

--- a/OlinkAnalyze/tests/testthat/test-Olink_bridgeselector.R
+++ b/OlinkAnalyze/tests/testthat/test-Olink_bridgeselector.R
@@ -4,9 +4,9 @@ bridgeSamples <- olink_bridgeselector(df = npx_data1,
 
 test_that("olink_bridgeselector works", {
   expect_equal(nrow(bridgeSamples), 8)
-  expect_equal(ncol(bridgeSamples), 4)
-  expect_equal(bridgeSamples$SampleID[3], 'A33')
-  expect_equal(round(bridgeSamples$MeanNPX[5], digits = 2), 6.08)
+  expect_equal(ncol(bridgeSamples), 3)
+  expect_equal(bridgeSamples[order(bridgeSamples$MeanNPX, decreasing = T),]$SampleID[3], 'A33')
+  expect_equal(round(bridgeSamples[order(bridgeSamples$MeanNPX, decreasing = T),]$MeanNPX[5], digits = 2), 6.08)
   expect_error(olink_bridgeselector(df = npx_data1,
                                     n = 8))
 })


### PR DESCRIPTION
Removing Order from output and randomizing output so bridge samples are not in decreasing mean NPX order.