### PR TITLE
added ability to actively prevent OlinkAnalyze from loading any fonts and setting them as part of theme

### DIFF
--- a/OlinkAnalyze/R/Olink_theme.R
+++ b/OlinkAnalyze/R/Olink_theme.R
@@ -20,19 +20,21 @@
 #'
 #'
 set_plot_theme <- function(font = "Swedish Gothic Thin") {
-
+  
   usefont <- ""
-
-  if (requireNamespace("extrafont", quietly = TRUE)) {
-    if(font %in% extrafont::fonts()){
-      if(.Platform$OS.type == "windows"){
-        extrafont::loadfonts(quiet = TRUE, device = "win")
+  
+  if (getOption("OlinkAnalyze.allow.font.load", default = TRUE)) {
+    if (requireNamespace("extrafont", quietly = TRUE)) {
+      if(font %in% extrafont::fonts()){
+        if(.Platform$OS.type == "windows"){
+          extrafont::loadfonts(quiet = TRUE, device = "win")
+        }
+        extrafont::loadfonts(quiet = TRUE, device = "pdf")
+        usefont <- font
       }
-      extrafont::loadfonts(quiet = TRUE, device = "pdf")
-      usefont <- font
     }
   }
-
+  
   olink_theme <- ggplot2::theme_bw() +
     ggplot2::theme(
       panel.grid.major = ggplot2::element_blank(),


### PR DESCRIPTION
I would like to make this addition since I noticed interference with the latest OlinkAnalyze version and Olink Insight development.

If the user executes `options(OlinkAnalyze.allow.font.load = FALSE)`, OlinkAnalyze will not load any system fonts and will not set the font as part of the ggplot theme for the remainder of that R session. Otherwise, everything will work as usual. That way we can use OlinkAnalyze without issues in Insight, where fonts are handled separately.

The name of the option follows the same style as for example `dplyr` session options.

The reason I want this as a session option is that there are other functions in OlinkAnalyze that call `set_plot_theme` (for example `olink_volcano_plot`) so it cannot be managed just via a function argument.

Since this is a pretty niche feature, I propose we keep it undocumented, at least for now.

(I have proposed two reviewers, but I think one is enough. So it depends on who might have time.)