### PR TITLE
Use TRUE/FALSE instead of T/F

### DIFF
--- a/OlinkAnalyze/R/Olink_anova.R
+++ b/OlinkAnalyze/R/Olink_anova.R
@@ -2,8 +2,8 @@
 #'
 #'Performs an ANOVA F-test for each assay (by OlinkID) in every panel using car::Anova and Type III sum of squares.
 #'The function handles both factor and numerical variables and/or covariates. \cr\cr
-#'Samples that have no variable information or missing factor levels are automatically removed from the analysis (specified in a messsage if verbose = T).
-#'Character columns in the input dataframe are automatically converted to factors (specified in a message if verbose = T).
+#'Samples that have no variable information or missing factor levels are automatically removed from the analysis (specified in a messsage if verbose = TRUE).
+#'Character columns in the input dataframe are automatically converted to factors (specified in a message if verbose = TRUE).
 #'Numerical variables are not converted to factors.
 #'If a numerical variable is to be used as a factor, this conversion needs to be done on the dataframe before the function call. \cr\cr
 #'Crossed analysis, i.e. A*B formula notation, is inferred from the variable argument in the following cases: \cr
@@ -12,9 +12,9 @@
 #' \item c('A: B')
 #' \item c('A: B', 'B') or c('A: B', 'A')
 #'}
-#'Inference is specified in a message if verbose = T. \cr
+#'Inference is specified in a message if verbose = TRUE. \cr
 #'For covariates, crossed analyses need to be specified explicity, i.e. two main effects will not be expaned with a c('A','B') notation. Main effects present in the variable takes precedence.
-#'The formula notation of the final model is specified in a message if verbose = T. \cr\cr
+#'The formula notation of the final model is specified in a message if verbose = TRUE. \cr\cr
 #'Adjusted p-values are calculated by stats::p.adjust according to the Benjamini & Hochberg (1995) method (“fdr”).
 #'The threshold is determined by logic evaluation of Adjusted_pval < 0.05. Covariates are not included in the p-value adjustment.
 #'
@@ -66,8 +66,8 @@ olink_anova <- function(df,
                         variable,
                         outcome="NPX",
                         covariates = NULL,
-                        return.covariates=F,
-                        verbose=T
+                        return.covariates = FALSE,
+                        verbose = TRUE
 ){
 
   if(missing(df) | missing(variable)){
@@ -124,7 +124,7 @@ olink_anova <- function(df,
       warning(paste0('The assays ',
                      paste(all_nas, collapse = ', '),
                      ' have only NA:s. They will not be tested.'),
-              call. = F)
+              call. = FALSE)
 
     }
 
@@ -177,12 +177,12 @@ olink_anova <- function(df,
                        ' has only NA:s in atleast one level of ',
                        effect,
                        '. It will not be tested.'),
-                call. = F)
+                call. = FALSE)
       }
 
       number_of_samples_w_more_than_one_level <- df %>%
         dplyr::group_by(SampleID, Index) %>%
-        dplyr::summarise(n_levels = dplyr::n_distinct(!!rlang::ensym(effect), na.rm = T)) %>%
+        dplyr::summarise(n_levels = dplyr::n_distinct(!!rlang::ensym(effect), na.rm = TRUE)) %>%
         dplyr::ungroup() %>%
         dplyr::filter(n_levels > 1) %>%
         nrow(.)
@@ -299,7 +299,7 @@ olink_anova <- function(df,
 #' Covariates to include. Takes ':' or '*' notation. Crossed analysis will not be inferred from main effects.
 #' @param outcome Character. The dependent variable. Default: NPX.
 #' @param effect Term on which to perform post-hoc. Character vector. Must be subset of or identical to variable.
-#' @param mean_return Boolean. If true, returns the mean of each factor level rather than the difference in means (default). Note that no p-value is returned for mean_return = T and no adjustment is performed.
+#' @param mean_return Boolean. If true, returns the mean of each factor level rather than the difference in means (default). Note that no p-value is returned for mean_return = TRUE and no adjustment is performed.
 #' @param verbose Boolean. Default: True. If information about removed samples, factor conversion and final model formula is to be printed to the console.
 #'
 #' @return Tibble of posthoc tests for specified effect, arranged by ascending adjusted p-values.
@@ -307,7 +307,7 @@ olink_anova <- function(df,
 #' @examples \donttest{
 #'
 #' library(dplyr)
-#' 
+#'
 #' npx_df <- npx_data1 %>% filter(!grepl('control',SampleID, ignore.case = TRUE))
 #'
 #' #Two-way ANOVA, one main effect (Site) covariate.
@@ -316,7 +316,7 @@ olink_anova <- function(df,
 #'                              variable=c("Treatment:Time"),
 #'                              covariates="Site")
 #'
-#' #Posthoc test for the model NPX~Treatment*Time+Site, 
+#' #Posthoc test for the model NPX~Treatment*Time+Site,
 #' #on the interaction effect Treatment:Time with covariate Site.
 #'
 #' #Filtering out significant and relevant results.
@@ -325,7 +325,7 @@ olink_anova <- function(df,
 #' select(OlinkID) %>%
 #' distinct() %>%
 #' pull()
-#' 
+#'
 #' #Posthoc
 #' anova_posthoc_results <- olink_anova_posthoc(npx_df,
 #' variable=c("Treatment:Time"),
@@ -340,10 +340,10 @@ olink_anova_posthoc <- function(df,
                                 olinkid_list = NULL,
                                 variable,
                                 covariates = NULL,
-                                outcome="NPX",
+                                outcome = "NPX",
                                 effect,
-                                mean_return=F,
-                                verbose=T
+                                mean_return = FALSE,
+                                verbose = TRUE
 ){
 
 
@@ -454,9 +454,9 @@ olink_anova_posthoc <- function(df,
       dplyr::do(data.frame(emmeans::emmeans(stats::lm(as.formula(formula_string),data=.),
                                     specs=as.formula(paste0("pairwise~", paste(effect,collapse="+"))),
                                     cov.reduce = function(x) round(c(mean(x),mean(x)+sd(x)),4),
-                            infer=c(T,T),
+                            infer=c(TRUE,TRUE),
                             adjust="tukey")[[c("contrasts","emmeans")[1+as.numeric(mean_return)]]],
-                    stringsAsFactors=F)) %>%
+                    stringsAsFactors=FALSE)) %>%
       dplyr::ungroup() %>%
       dplyr::mutate(term=paste(effect,collapse=":"))  %>%
       dplyr::rename(conf.low=lower.CL,

--- a/OlinkAnalyze/R/Olink_boxplot.R
+++ b/OlinkAnalyze/R/Olink_boxplot.R
@@ -39,7 +39,7 @@
 olink_boxplot <- function(df,
                           variable,
                           olinkid_list,
-                          verbose = F,
+                          verbose = FALSE,
                           number_of_proteins_per_plot = 6,
                           ...){
 
@@ -131,7 +131,7 @@ olink_boxplot <- function(df,
       dplyr::mutate(OlinkID = factor(OlinkID, levels = assays_for_plotting)) %>%
       dplyr::select(OlinkID, UniProt, Assay, NPX, eval(variable)) %>%
       with(., .[order(OlinkID),]) %>%
-      tidyr::unite(c(Assay, OlinkID), col = 'Name_OID', sep = ' ', remove = F) %>%
+      tidyr::unite(c(Assay, OlinkID), col = 'Name_OID', sep = ' ', remove = FALSE) %>%
       dplyr::mutate(Name_OID = forcats::as_factor(Name_OID))
 
 

--- a/OlinkAnalyze/R/Olink_bridgeselector.R
+++ b/OlinkAnalyze/R/Olink_bridgeselector.R
@@ -2,7 +2,7 @@
 #'
 #'The bridge selection function will select a number of bridge samples based on the input data. It selects samples with
 #'good detection, which passes QC and cover a good range of the data. If possible, Olink recommends 8-16 bridge samples.
-#'When running the selector, Olink recommends starting at sampleMissingFreq = 0.010 which represents a maximum of 10\% 
+#'When running the selector, Olink recommends starting at sampleMissingFreq = 0.010 which represents a maximum of 10\%
 #'data below LOD per sample. If there are not enough samples output, increase to 20\%. \cr\cr
 #'The function accepts NPX Excel files with data < LOD replaced.
 #'
@@ -21,7 +21,7 @@
 
 olink_bridgeselector<-function(df, sampleMissingFreq, n){
 
-  
+
   #Filtering on valid OlinkID
   df <- df %>%
     dplyr::filter(stringr::str_detect(OlinkID,
@@ -34,16 +34,16 @@ olink_bridgeselector<-function(df, sampleMissingFreq, n){
   #Outlier calculation as in qc_plot for filtering
   qc_outliers <- df %>%
     dplyr::group_by(Panel, SampleID, Index) %>%
-    dplyr::mutate(IQR = IQR(NPX, na.rm = T),
-           sample_median = median(NPX, na.rm = T)) %>%
+    dplyr::mutate(IQR = IQR(NPX, na.rm = TRUE),
+           sample_median = median(NPX, na.rm = TRUE)) %>%
     dplyr::ungroup() %>%
     dplyr::select(SampleID, Index, Panel, IQR, sample_median) %>%
     dplyr::distinct() %>%
     dplyr::group_by(Panel) %>%
-    dplyr::mutate(median_low = mean(sample_median, na.rm = T) - 3*sd(sample_median, na.rm = T),
-           median_high = mean(sample_median, na.rm = T) + 3*sd(sample_median, na.rm = T),
-           iqr_low = mean(IQR, na.rm = T) - 3*sd(IQR, na.rm = T),
-           iqr_high = mean(IQR, na.rm = T) + 3*sd(IQR, na.rm = T)) %>%
+    dplyr::mutate(median_low = mean(sample_median, na.rm = TRUE) - 3*sd(sample_median, na.rm = TRUE),
+           median_high = mean(sample_median, na.rm = TRUE) + 3*sd(sample_median, na.rm = TRUE),
+           iqr_low = mean(IQR, na.rm = TRUE) - 3*sd(IQR, na.rm = TRUE),
+           iqr_high = mean(IQR, na.rm = TRUE) + 3*sd(IQR, na.rm = TRUE)) %>%
     dplyr::ungroup() %>%
     dplyr::mutate(Outlier = if_else(sample_median < median_high &
                                sample_median > median_low &
@@ -63,11 +63,11 @@ olink_bridgeselector<-function(df, sampleMissingFreq, n){
     dplyr::mutate(Outliers = sum(Outlier)) %>%
     dplyr::filter(Outliers == 0) %>%
     dplyr::mutate(PercAssaysBelowLOD = sum(is.na(NPX))/dplyr::n()) %>%
-    dplyr::mutate(MeanNPX = mean(NPX, na.rm = T)) %>%
+    dplyr::mutate(MeanNPX = mean(NPX, na.rm = TRUE)) %>%
     dplyr::ungroup() %>%
     dplyr::filter(PercAssaysBelowLOD < sampleMissingFreq)
-  
-  
+
+
   df_2 <- df_1 %>%
     dplyr::select(SampleID, PercAssaysBelowLOD, MeanNPX) %>%
     dplyr::distinct() %>%

--- a/OlinkAnalyze/R/Olink_plate_randomizer.R
+++ b/OlinkAnalyze/R/Olink_plate_randomizer.R
@@ -9,12 +9,12 @@
 #' @export
 #' @examples
 #' \donttest{randomized.manifest <- olink_plate_randomizer(manifest)}
-#' \donttest{displayPlateLayout(data=randomized.manifest,fill.color="Site")}
+#' \donttest{displayPlateLayout(data = randomized.manifest, fill.color="Site")}
 #' @importFrom magrittr %>%
 #' @importFrom dplyr n filter select mutate
 #' @importFrom ggplot2 ggplot geom_tile facet_wrap scale_fill_manual labs scale_x_discrete geom_text
 
-displayPlateLayout <- function(data,fill.color,PlateSize = 96, include.label=F){
+displayPlateLayout <- function(data, fill.color, PlateSize = 96, include.label=FALSE){
 
   if(!PlateSize %in% c(48,96)){
     stop('Plate size needs to be either 48 or 96.')
@@ -138,7 +138,7 @@ generatePlateHolder <- function(n.plates,n.spots,n.samples, PlateSize){
                               stringsAsFactors = TRUE) %>%
     dplyr::arrange(column,row)
   plates <- paste0("Plate ",1:n.plates)
-  out <- data.frame(plate=NULL,column=NULL,row=NULL,stringsAsFactors = F)
+  out <- data.frame(plate = NULL, column = NULL, row = NULL, stringsAsFactors = FALSE)
   for(i in 1:n.plates){
     hld <- cbind(plate=rep(paste0("Plate ",i),n.spots[i]),
                  full.row.col[1:n.spots[i],])
@@ -151,7 +151,7 @@ generatePlateHolder <- function(n.plates,n.spots,n.samples, PlateSize){
 
 #' Randomly assign samples to plates
 #'
-#' Samples can be randomly assigned to plates using base::sample with an option to keep Subjects on the same plate.  Olink Data Science no longer recommends forced balanced randomization considering other clinical variables. 
+#' Samples can be randomly assigned to plates using base::sample with an option to keep Subjects on the same plate.  Olink Data Science no longer recommends forced balanced randomization considering other clinical variables.
 #' @param Manifest tibble/data frame in long format containing all sample ID's. Sample ID column must be named SampleID.
 #' @param PlateSize Integer. Either 96 or 48. 96 is default.
 #' @param SubjectColumn (Optional) Column name of the subject ID column. Cannot contain missings. If provided, subjects are kept on the same plate.
@@ -239,7 +239,7 @@ olink_plate_randomizer <-function(Manifest, PlateSize = 96, SubjectColumn, itera
         } else if(is.character(all.plates.tmp)){
           passed <- FALSE
           break}
-        passed <- T
+        passed <- TRUE
       }
 
       if(passed){

--- a/OlinkAnalyze/R/Olink_ttest.R
+++ b/OlinkAnalyze/R/Olink_ttest.R
@@ -174,10 +174,10 @@ olink_ttest <- function(df, variable, pair_id, ...){
     p.val <- df %>%
       dplyr::filter(!(OlinkID %in% all_nas)) %>%
       dplyr::filter(!(OlinkID %in% nas_in_level)) %>%
-      dplyr::select(dplyr::all_of(c("OlinkID","UniProt","Assay","Panel","NPX",variable,pair_id))) %>%
-      tidyr::pivot_wider(names_from=dplyr::all_of(variable),values_from="NPX") %>%
+      dplyr::select(dplyr::all_of(c("OlinkID", "UniProt", "Assay", "Panel", "NPX", variable, pair_id))) %>%
+      tidyr::pivot_wider(names_from = dplyr::all_of(variable), values_from = "NPX") %>%
       dplyr::group_by(Assay, OlinkID, UniProt, Panel) %>%
-      dplyr::do(broom::tidy(t.test(x=.[[var_levels[1]]],y=.[[var_levels[2]]],paired=T, ...))) %>%
+      dplyr::do(broom::tidy(t.test(x = .[[var_levels[1]]], y = .[[var_levels[2]]], paired = TRUE, ...))) %>%
       dplyr::ungroup() %>%
       dplyr::mutate(Adjusted_pval = p.adjust(p.value, method = "fdr")) %>%
       dplyr::mutate(Threshold = ifelse(Adjusted_pval < 0.05, "Significant", "Non-significant")) %>%

--- a/OlinkAnalyze/R/Read_NPX_data.R
+++ b/OlinkAnalyze/R/Read_NPX_data.R
@@ -25,11 +25,11 @@ read_NPX <- function(filename){
   # If the file is csv or txt, read_NPX assumes that the file is explore data in long format
   if (tools::file_ext(filename) %in% c("csv","txt")) {
     #read file using ; as delimiter
-    out <- read.table(filename, header = TRUE, sep=";", stringsAsFactors = F,
+    out <- read.table(filename, header = TRUE, sep=";", stringsAsFactors = FALSE,
                       na.strings = c("NA",""))
     if (is.data.frame(out) & ncol(out) == 1) {
       #if only one column in the data, wrong delimiter. use , as delimiter
-      out <- read.table(filename, header = TRUE, sep=",", stringsAsFactors = F,
+      out <- read.table(filename, header = TRUE, sep=",", stringsAsFactors = FALSE,
                         na.strings = c("NA",""))
     }
     #check that all colnames are present
@@ -59,14 +59,14 @@ read_NPX <- function(filename){
   # Check if the data is npx or concentration as well as if it is tg48 or tg96
 
   data_type <- readxl::read_excel(filename, range='A2',
-                                  col_names = F, .name_repair="minimal")
+                                  col_names = FALSE, .name_repair="minimal")
   if (grepl('NPX', data_type, fixed=TRUE)) {
     is_npx_data <- TRUE
     n_max_meta_data <- 4
 
     # Check whether it is target 48 or 96
     panel_name <- readxl::read_excel(filename, range='B3',
-                                     col_names = F, .name_repair="minimal")
+                                     col_names = FALSE, .name_repair="minimal")
     if (grepl('Target 48', panel_name, fixed=TRUE)) {
       target_type <- '48'
       BASE_INDEX <- 45
@@ -86,7 +86,7 @@ read_NPX <- function(filename){
 
   # Load initial meta data (the first rows of the wide file)
   meta_dat <-  readxl::read_excel(filename, skip = 2, n_max = n_max_meta_data,
-                                  col_names = F, .name_repair="minimal")
+                                  col_names = FALSE, .name_repair="minimal")
   meta_dat[4,1] <- 'SampleID'
   NR_DEVIATIONS <- sum(stringr::str_detect(meta_dat[2,],
                                            'QC Deviation from median'))
@@ -106,7 +106,7 @@ read_NPX <- function(filename){
     dplyr::rename(Name = `1`)
 
   # Load NPX or QUANT data including the last rows of meta data
-  dat <- readxl::read_excel(filename, skip = n_max_meta_data+2, col_names = F,
+  dat <- readxl::read_excel(filename, skip = n_max_meta_data+2, col_names = FALSE,
                             .name_repair="minimal", col_types = c('text'))
 
   nr_col <- ncol(dat)
@@ -302,16 +302,16 @@ read_NPX <- function(filename){
     dplyr::mutate(Panel_Version = gsub(".*\\(","",Panel)) %>%
     dplyr::mutate(Panel_Version = gsub("\\)","",Panel_Version)) %>%
     dplyr::mutate(Panel =  gsub("\\(.*\\)","",Panel)) %>%
-    dplyr::mutate(Panel = stringr::str_to_title(Panel)) %>% 
-    dplyr::mutate(Panel = gsub("Target 96", "", Panel)) %>% 
-    dplyr::mutate(Panel = gsub("Olink", "", Panel)) %>% 
-    dplyr::mutate(Panel = trimws(Panel, which = "left")) %>% 
-    tidyr::separate(Panel, " ", into = c("Panel_Start", "Panel_End"), fill = "right") %>% 
+    dplyr::mutate(Panel = stringr::str_to_title(Panel)) %>%
+    dplyr::mutate(Panel = gsub("Target 96", "", Panel)) %>%
+    dplyr::mutate(Panel = gsub("Olink", "", Panel)) %>%
+    dplyr::mutate(Panel = trimws(Panel, which = "left")) %>%
+    tidyr::separate(Panel, " ", into = c("Panel_Start", "Panel_End"), fill = "right") %>%
     dplyr::mutate(Panel_End = ifelse(grepl("Ii", Panel_End), stringr::str_to_upper(Panel_End), Panel_End)) %>%
-    dplyr::mutate(Panel_End = ifelse(is.na(Panel_End), " ", Panel_End)) %>% 
-    dplyr::mutate(Panel = paste("Olink", Panel_Start, Panel_End)) %>% 
-    dplyr::mutate(Panel = trimws(Panel, which = "right")) %>% 
-    dplyr::select(-Panel_Start, -Panel_End) %>% 
+    dplyr::mutate(Panel_End = ifelse(is.na(Panel_End), " ", Panel_End)) %>%
+    dplyr::mutate(Panel = paste("Olink", Panel_Start, Panel_End)) %>%
+    dplyr::mutate(Panel = trimws(Panel, which = "right")) %>%
+    dplyr::select(-Panel_Start, -Panel_End) %>%
     dplyr::select(SampleID, Index, OlinkID,
                   UniProt, Assay, MissingFreq,
                   Panel,Panel_Version,PlateID,

--- a/OlinkAnalyze/R/Volcano_plot.R
+++ b/OlinkAnalyze/R/Volcano_plot.R
@@ -69,7 +69,7 @@ olink_volcano_plot <- function (p.val_tbl, x_lab = "Estimate", olinkid_list = NU
     ggplot2::geom_point() +
     ggplot2::labs(x = x_lab, y = "-log10(p-value)") +
     ggrepel::geom_label_repel(data = subset(p.val_tbl, OlinkID %in% olinkid_list),
-                              ggplot2::aes(label = Assay), box.padding = 1, show.legend = F) +
+                              ggplot2::aes(label = Assay), box.padding = 1, show.legend = FALSE) +
     ggplot2::geom_hline(yintercept = -log10(0.05), linetype="dotted") +
     OlinkAnalyze::set_plot_theme() +
     OlinkAnalyze::olink_color_discrete(...)

--- a/OlinkAnalyze/R/linear_mixed_model.R
+++ b/OlinkAnalyze/R/linear_mixed_model.R
@@ -2,8 +2,8 @@
 #'
 #'Fits a linear mixed effects model for every protein (by OlinkID) in every panel, using lmerTest::lmer and stats::anova.
 #'The function handles both factor and numerical variables and/or covariates. \cr\cr
-#'Samples that have no variable information or missing factor levels are automatically removed from the analysis (specified in a messsage if verbose = T).
-#'Character columns in the input dataframe are automatically converted to factors (specified in a message if verbose = T).
+#'Samples that have no variable information or missing factor levels are automatically removed from the analysis (specified in a messsage if verbose = TRUE).
+#'Character columns in the input dataframe are automatically converted to factors (specified in a message if verbose = TRUE).
 #'Numerical variables are not converted to factors.
 #'If a numerical variable is to be used as a factor, this conversion needs to be done on the dataframe before the function call. \cr\cr
 #'Crossed analysis, i.e. A*B formula notation, is inferred from the variable argument in the following cases: \cr
@@ -12,10 +12,10 @@
 #' \item c('A:B')
 #' \item c('A:B', 'B') or c('A:B', 'A')
 #'}
-#'Inference is specified in a message if verbose = T. \cr
+#'Inference is specified in a message if verbose = TRUE. \cr
 #'For covariates, crossed analyses need to be specified explicity, i.e. two main effects will not be expaned with a c('A','B') notation. Main effects present in the variable takes precedence. \cr
 #'The random variable only takes main effect(s). \cr
-#'The formula notation of the final model is specified in a message if verbose = T. \cr\cr
+#'The formula notation of the final model is specified in a message if verbose = TRUE. \cr\cr
 #'Output p-values are adjusted by stats::p.adjust according to the Benjamini-Hochberg method (“fdr”).
 #'Adjusted p-values are logically evaluated towards adjusted p-value<0.05.
 #'
@@ -52,8 +52,8 @@ olink_lmer <- function(df,
                        outcome="NPX",
                        random,
                        covariates = NULL,
-                       return.covariates=F,
-                       verbose=T
+                       return.covariates = FALSE,
+                       verbose = TRUE
 ) {
 
   if(missing(df) | missing(variable) | missing(random)){
@@ -111,7 +111,7 @@ olink_lmer <- function(df,
       warning(paste0('The assays ',
                      paste(all_nas, collapse = ', '),
                      ' have only NA:s. They will not be tested.'),
-              call. = F)
+              call. = FALSE)
 
     }
 
@@ -163,12 +163,12 @@ olink_lmer <- function(df,
                        ' has only NA:s in atleast one level of ',
                        effect,
                        '. It will not be tested.'),
-                call. = F)
+                call. = FALSE)
       }
 
       number_of_samples_w_more_than_one_level <- df %>%
         dplyr::group_by(SampleID, Index) %>%
-        dplyr::summarise(n_levels = n_distinct(!!rlang::ensym(effect), na.rm = T)) %>%
+        dplyr::summarise(n_levels = n_distinct(!!rlang::ensym(effect), na.rm = TRUE)) %>%
         dplyr::ungroup() %>%
         dplyr::filter(n_levels > 1) %>%
         nrow(.)
@@ -268,15 +268,15 @@ olink_lmer <- function(df,
 single_lmer <- function(data, formula_string){
 
   out.model <- tryCatch(lmerTest::lmer(as.formula(formula_string),
-                                       data=data,
-                                       REML=F,
+                                       data = data,
+                                       REML = FALSE,
                                        control = lme4::lmerControl(check.conv.singular = "ignore")),
                         warning = function(w){
                           return(
                             lmerTest::lmer(as.formula(formula_string),
-                                           data=data,
-                                           REML=F,
-                                           control= lme4::lmerControl(optimizer = "Nelder_Mead",
+                                           data = data,
+                                           REML = FALSE,
+                                           control = lme4::lmerControl(optimizer = "Nelder_Mead",
                                                                check.conv.singular = "ignore"))
                           )
 
@@ -309,7 +309,7 @@ single_lmer <- function(data, formula_string){
 #' @param random Single character value or character array.
 #' @param covariates Single character value or character array. Default: NULL.
 #' Covariates to include. Takes ':' or '*' notation. Crossed analysis will not be inferred from main effects.
-#' @param mean_return Boolean. If true, returns the mean of each factor level rather than the difference in means (default). Note that no p-value is returned for mean_return = T and no adjustment is performed.
+#' @param mean_return Boolean. If true, returns the mean of each factor level rather than the difference in means (default). Note that no p-value is returned for mean_return = TRUE and no adjustment is performed.
 #' @param verbose Boolean. Deafult: True. If information about removed samples, factor conversion and final model formula is to be printed to the console.
 #' @param variable Single character value or character array.
 #' Variable(s) to test. If length > 1, the included variable names will be used in crossed analyses .
@@ -351,8 +351,8 @@ olink_lmer_posthoc <- function(df,
                                outcome="NPX",
                                random,
                                covariates = NULL,
-                               mean_return=F,
-                               verbose=T
+                               mean_return = FALSE,
+                               verbose = TRUE
 ){
 
 
@@ -493,9 +493,9 @@ single_posthoc <- function(data, formula_string, effect, mean_return){
                                 specs=as.formula(paste0("pairwise~", paste(effect,collapse="+"))),
                                 cov.reduce = function(x) round(c(mean(x),mean(x)+sd(x)),4),
                                 lmer.df="satterthwaite",
-                                infer = c(T,T), 
+                                infer = c(TRUE, TRUE),
                                 adjust = 'tukey')
-  
+
   if(mean_return){
     tmp <- unique(unlist(strsplit(effect,":")))
     return(as_tibble(the_model$emmeans) %>%
@@ -581,7 +581,7 @@ olink_lmer_plot <- function(df,
                             x_axis_variable,
                             col_variable = NULL,
                             number_of_proteins_per_plot = 6,
-                            verbose=F,
+                            verbose = FALSE,
                             ...
                             ){
 
@@ -656,7 +656,7 @@ olink_lmer_plot <- function(df,
                                  olinkid_list = olinkid_list,
                                  covariates=covariates,
                                  effect = current_fixed_effect,
-                                 mean_return = T,
+                                 mean_return = TRUE,
                                  verbose=verbose) %>%
     dplyr::mutate(Name_Assay = paste0(Assay,"_",OlinkID))
 

--- a/OlinkAnalyze/R/olink_qc_plot.R
+++ b/OlinkAnalyze/R/olink_qc_plot.R
@@ -87,16 +87,16 @@ olink_qc_plot <- function(df,
     dplyr::mutate(QC_Warning = dplyr::if_else(all(toupper(QC_Warning) == 'PASS'),
                                               'Pass',
                                               'Warning')) %>%
-    dplyr::mutate(IQR = IQR(NPX, na.rm = T),
-                  sample_median = median(NPX, na.rm = T)) %>%
+    dplyr::mutate(IQR = IQR(NPX, na.rm = TRUE),
+                  sample_median = median(NPX, na.rm = TRUE)) %>%
     dplyr::ungroup() %>%
     dplyr::select(SampleID, Index, Panel, IQR, sample_median, !!rlang::ensym(color_g)) %>%
     dplyr::distinct() %>%
     dplyr::group_by(Panel) %>%
-    dplyr::mutate(median_low = mean(sample_median, na.rm = T) - median_outlierDef*sd(sample_median, na.rm = T),
-                  median_high = mean(sample_median, na.rm = T) + median_outlierDef*sd(sample_median, na.rm = T),
-                  iqr_low = mean(IQR, na.rm = T) - IQR_outlierDef*sd(IQR, na.rm = T),
-                  iqr_high = mean(IQR, na.rm = T) + IQR_outlierDef*sd(IQR, na.rm = T)) %>%
+    dplyr::mutate(median_low = mean(sample_median, na.rm = TRUE) - median_outlierDef*sd(sample_median, na.rm = TRUE),
+                  median_high = mean(sample_median, na.rm = TRUE) + median_outlierDef*sd(sample_median, na.rm = TRUE),
+                  iqr_low = mean(IQR, na.rm = TRUE) - IQR_outlierDef*sd(IQR, na.rm = TRUE),
+                  iqr_high = mean(IQR, na.rm = TRUE) + IQR_outlierDef*sd(IQR, na.rm = TRUE)) %>%
     dplyr::ungroup() %>%
     dplyr::mutate(Outlier = dplyr::if_else(sample_median < median_high &
                                              sample_median > median_low &

--- a/OlinkAnalyze/R/pca_plot.R
+++ b/OlinkAnalyze/R/pca_plot.R
@@ -117,7 +117,7 @@ olink_pca_plot <- function (df,
     stop('To label outliers, both outlierDefX and outlierDefY have to be specified as numerical values')
   }
 
-  #If outlierLines == T, both outlierDefX and outlierDefY have to be specified
+  #If outlierLines == TRUE, both outlierDefX and outlierDefY have to be specified
   if(outlierLines){
     if(!all(is.numeric(outlierDefX), is.numeric(outlierDefY))){
       stop('outlierLines requested but boundaries not specified. To draw lines, both outlierDefX and outlierDefY have to be specified as numerical values')
@@ -154,7 +154,7 @@ olink_pca_plot <- function (df,
       g
     })
     names(plotList) <- unique(df$Panel)
-    if(!quiet) print(ggpubr::ggarrange(plotlist = plotList, common.legend = T))
+    if(!quiet) print(ggpubr::ggarrange(plotlist = plotList, common.legend = TRUE))
 
   } else{
     pca_plot <- olink_pca_plot.internal(df = df,
@@ -289,7 +289,7 @@ olink_pca_plot.internal <- function (df,
     }
 
     if(ncol(df_wide) < 4){
-      stop('Too many assays removed. Set drop_assays = F for imputation.')
+      stop('Too many assays removed. Set drop_assays = FALSE for imputation.')
     }
   }
 
@@ -307,7 +307,7 @@ olink_pca_plot.internal <- function (df,
 
     if(nrow(df_wide) < 2){
 
-      stop('Too many samples removed. Set drop_samples = F for imputation.')
+      stop('Too many samples removed. Set drop_samples = FALSE for imputation.')
     }
 
   }
@@ -434,10 +434,10 @@ olink_pca_plot.internal <- function (df,
   if(!is.na(outlierDefX) & !is.na(outlierDefY)){
     scores <- scores %>%
       tibble::rownames_to_column(var = 'SampleID') %>%
-      dplyr::mutate( PCX_low = mean(PCX, na.rm = T) - outlierDefX*sd(PCX, na.rm = T),
-                     PCX_high = mean(PCX, na.rm = T) + outlierDefX*sd(PCX, na.rm = T),
-                     PCY_low = mean(PCY, na.rm = T) - outlierDefY*sd(PCY, na.rm = T),
-                     PCY_high = mean(PCY, na.rm = T) + outlierDefY*sd(PCY, na.rm = T)) %>%
+      dplyr::mutate( PCX_low = mean(PCX, na.rm = TRUE) - outlierDefX*sd(PCX, na.rm = TRUE),
+                     PCX_high = mean(PCX, na.rm = TRUE) + outlierDefX*sd(PCX, na.rm = TRUE),
+                     PCY_low = mean(PCY, na.rm = TRUE) - outlierDefY*sd(PCY, na.rm = TRUE),
+                     PCY_high = mean(PCY, na.rm = TRUE) + outlierDefY*sd(PCY, na.rm = TRUE)) %>%
       dplyr::mutate(Outlier = dplyr::if_else(PCX < PCX_high &
                                                PCX > PCX_low &
                                                PCY > PCY_low &

--- a/OlinkAnalyze/man/displayPlateLayout.Rd
+++ b/OlinkAnalyze/man/displayPlateLayout.Rd
@@ -4,7 +4,7 @@
 \alias{displayPlateLayout}
 \title{Plot all plates colored by a variable}
 \usage{
-displayPlateLayout(data, fill.color, PlateSize = 96, include.label = F)
+displayPlateLayout(data, fill.color, PlateSize = 96, include.label = FALSE)
 }
 \arguments{
 \item{data}{tibble/data frame in long format returned from the olink_plate_randomizer function.}
@@ -20,7 +20,7 @@ Displays each plate in a facet with cells colored by the given variable using gg
 }
 \examples{
 \donttest{randomized.manifest <- olink_plate_randomizer(manifest)}
-\donttest{displayPlateLayout(data=randomized.manifest,fill.color="Site")}
+\donttest{displayPlateLayout(data = randomized.manifest, fill.color="Site")}
 }
 \keyword{ggplot}
 \keyword{plates,}

--- a/OlinkAnalyze/man/olink_anova.Rd
+++ b/OlinkAnalyze/man/olink_anova.Rd
@@ -9,8 +9,8 @@ olink_anova(
   variable,
   outcome = "NPX",
   covariates = NULL,
-  return.covariates = F,
-  verbose = T
+  return.covariates = FALSE,
+  verbose = TRUE
 )
 }
 \arguments{
@@ -36,8 +36,8 @@ The tibble is arranged by ascending p-values.
 \description{
 Performs an ANOVA F-test for each assay (by OlinkID) in every panel using car::Anova and Type III sum of squares.
 The function handles both factor and numerical variables and/or covariates. \cr\cr
-Samples that have no variable information or missing factor levels are automatically removed from the analysis (specified in a messsage if verbose = T).
-Character columns in the input dataframe are automatically converted to factors (specified in a message if verbose = T).
+Samples that have no variable information or missing factor levels are automatically removed from the analysis (specified in a messsage if verbose = TRUE).
+Character columns in the input dataframe are automatically converted to factors (specified in a message if verbose = TRUE).
 Numerical variables are not converted to factors.
 If a numerical variable is to be used as a factor, this conversion needs to be done on the dataframe before the function call. \cr\cr
 Crossed analysis, i.e. A*B formula notation, is inferred from the variable argument in the following cases: \cr
@@ -46,9 +46,9 @@ Crossed analysis, i.e. A*B formula notation, is inferred from the variable argum
 \item c('A: B')
 \item c('A: B', 'B') or c('A: B', 'A')
 }
-Inference is specified in a message if verbose = T. \cr
+Inference is specified in a message if verbose = TRUE. \cr
 For covariates, crossed analyses need to be specified explicity, i.e. two main effects will not be expaned with a c('A','B') notation. Main effects present in the variable takes precedence.
-The formula notation of the final model is specified in a message if verbose = T. \cr\cr
+The formula notation of the final model is specified in a message if verbose = TRUE. \cr\cr
 Adjusted p-values are calculated by stats::p.adjust according to the Benjamini & Hochberg (1995) method (“fdr”).
 The threshold is determined by logic evaluation of Adjusted_pval < 0.05. Covariates are not included in the p-value adjustment.
 }

--- a/OlinkAnalyze/man/olink_anova_posthoc.Rd
+++ b/OlinkAnalyze/man/olink_anova_posthoc.Rd
@@ -11,8 +11,8 @@ olink_anova_posthoc(
   covariates = NULL,
   outcome = "NPX",
   effect,
-  mean_return = F,
-  verbose = T
+  mean_return = FALSE,
+  verbose = TRUE
 )
 }
 \arguments{
@@ -31,7 +31,7 @@ Covariates to include. Takes ':' or '*' notation. Crossed analysis will not be i
 
 \item{effect}{Term on which to perform post-hoc. Character vector. Must be subset of or identical to variable.}
 
-\item{mean_return}{Boolean. If true, returns the mean of each factor level rather than the difference in means (default). Note that no p-value is returned for mean_return = T and no adjustment is performed.}
+\item{mean_return}{Boolean. If true, returns the mean of each factor level rather than the difference in means (default). Note that no p-value is returned for mean_return = TRUE and no adjustment is performed.}
 
 \item{verbose}{Boolean. Default: True. If information about removed samples, factor conversion and final model formula is to be printed to the console.}
 }
@@ -58,7 +58,7 @@ anova_results <- olink_anova(df = npx_df,
                              variable=c("Treatment:Time"),
                              covariates="Site")
 
-#Posthoc test for the model NPX~Treatment*Time+Site, 
+#Posthoc test for the model NPX~Treatment*Time+Site,
 #on the interaction effect Treatment:Time with covariate Site.
 
 #Filtering out significant and relevant results.

--- a/OlinkAnalyze/man/olink_boxplot.Rd
+++ b/OlinkAnalyze/man/olink_boxplot.Rd
@@ -8,7 +8,7 @@ olink_boxplot(
   df,
   variable,
   olinkid_list,
-  verbose = F,
+  verbose = FALSE,
   number_of_proteins_per_plot = 6,
   ...
 )

--- a/OlinkAnalyze/man/olink_bridgeselector.Rd
+++ b/OlinkAnalyze/man/olink_bridgeselector.Rd
@@ -19,7 +19,7 @@ Tibble with sample IDs and mean NPX for a defined number of bridging samples.
 \description{
 The bridge selection function will select a number of bridge samples based on the input data. It selects samples with
 good detection, which passes QC and cover a good range of the data. If possible, Olink recommends 8-16 bridge samples.
-When running the selector, Olink recommends starting at sampleMissingFreq = 0.010 which represents a maximum of 10\% 
+When running the selector, Olink recommends starting at sampleMissingFreq = 0.010 which represents a maximum of 10\%
 data below LOD per sample. If there are not enough samples output, increase to 20\%. \cr\cr
 The function accepts NPX Excel files with data < LOD replaced.
 }

--- a/OlinkAnalyze/man/olink_lmer.Rd
+++ b/OlinkAnalyze/man/olink_lmer.Rd
@@ -10,8 +10,8 @@ olink_lmer(
   outcome = "NPX",
   random,
   covariates = NULL,
-  return.covariates = F,
-  verbose = T
+  return.covariates = FALSE,
+  verbose = TRUE
 )
 }
 \arguments{
@@ -38,8 +38,8 @@ A tibble containing the results of fitting the linear mixed effects model to eve
 \description{
 Fits a linear mixed effects model for every protein (by OlinkID) in every panel, using lmerTest::lmer and stats::anova.
 The function handles both factor and numerical variables and/or covariates. \cr\cr
-Samples that have no variable information or missing factor levels are automatically removed from the analysis (specified in a messsage if verbose = T).
-Character columns in the input dataframe are automatically converted to factors (specified in a message if verbose = T).
+Samples that have no variable information or missing factor levels are automatically removed from the analysis (specified in a messsage if verbose = TRUE).
+Character columns in the input dataframe are automatically converted to factors (specified in a message if verbose = TRUE).
 Numerical variables are not converted to factors.
 If a numerical variable is to be used as a factor, this conversion needs to be done on the dataframe before the function call. \cr\cr
 Crossed analysis, i.e. A*B formula notation, is inferred from the variable argument in the following cases: \cr
@@ -48,10 +48,10 @@ Crossed analysis, i.e. A*B formula notation, is inferred from the variable argum
 \item c('A:B')
 \item c('A:B', 'B') or c('A:B', 'A')
 }
-Inference is specified in a message if verbose = T. \cr
+Inference is specified in a message if verbose = TRUE. \cr
 For covariates, crossed analyses need to be specified explicity, i.e. two main effects will not be expaned with a c('A','B') notation. Main effects present in the variable takes precedence. \cr
 The random variable only takes main effect(s). \cr
-The formula notation of the final model is specified in a message if verbose = T. \cr\cr
+The formula notation of the final model is specified in a message if verbose = TRUE. \cr\cr
 Output p-values are adjusted by stats::p.adjust according to the Benjamini-Hochberg method (“fdr”).
 Adjusted p-values are logically evaluated towards adjusted p-value<0.05.
 }

--- a/OlinkAnalyze/man/olink_lmer_plot.Rd
+++ b/OlinkAnalyze/man/olink_lmer_plot.Rd
@@ -14,7 +14,7 @@ olink_lmer_plot(
   x_axis_variable,
   col_variable = NULL,
   number_of_proteins_per_plot = 6,
-  verbose = F,
+  verbose = FALSE,
   ...
 )
 }

--- a/OlinkAnalyze/man/olink_lmer_posthoc.Rd
+++ b/OlinkAnalyze/man/olink_lmer_posthoc.Rd
@@ -12,8 +12,8 @@ olink_lmer_posthoc(
   outcome = "NPX",
   random,
   covariates = NULL,
-  mean_return = F,
-  verbose = T
+  mean_return = FALSE,
+  verbose = TRUE
 )
 }
 \arguments{
@@ -34,7 +34,7 @@ Also takes ':' or '*' notation.}
 \item{covariates}{Single character value or character array. Default: NULL.
 Covariates to include. Takes ':' or '*' notation. Crossed analysis will not be inferred from main effects.}
 
-\item{mean_return}{Boolean. If true, returns the mean of each factor level rather than the difference in means (default). Note that no p-value is returned for mean_return = T and no adjustment is performed.}
+\item{mean_return}{Boolean. If true, returns the mean of each factor level rather than the difference in means (default). Note that no p-value is returned for mean_return = TRUE and no adjustment is performed.}
 
 \item{verbose}{Boolean. Deafult: True. If information about removed samples, factor conversion and final model formula is to be printed to the console.}
 }

--- a/OlinkAnalyze/tests/testthat/test-Olink_bridgeselector.R
+++ b/OlinkAnalyze/tests/testthat/test-Olink_bridgeselector.R
@@ -5,8 +5,8 @@ bridgeSamples <- olink_bridgeselector(df = npx_data1,
 test_that("olink_bridgeselector works", {
   expect_equal(nrow(bridgeSamples), 8)
   expect_equal(ncol(bridgeSamples), 3)
-  expect_equal(bridgeSamples[order(bridgeSamples$MeanNPX, decreasing = T),]$SampleID[3], 'A70')
-  expect_equal(round(bridgeSamples[order(bridgeSamples$MeanNPX, decreasing = T),]$MeanNPX[5], digits = 2), 6.21)
+  expect_equal(bridgeSamples[order(bridgeSamples$MeanNPX, decreasing = TRUE),]$SampleID[3], 'A70')
+  expect_equal(round(bridgeSamples[order(bridgeSamples$MeanNPX, decreasing = TRUE),]$MeanNPX[5], digits = 2), 6.21)
   expect_error(olink_bridgeselector(df = npx_data1,
                                     n = 8))
 })

--- a/OlinkAnalyze/tests/testthat/test-Read_NPX_data.R
+++ b/OlinkAnalyze/tests/testthat/test-Read_NPX_data.R
@@ -1,9 +1,9 @@
 test_that("Data loads correctly with 'read_NPX()'", {
   #Read data
-  npx_file <- system.file("extdata", "npx_data1.xlsx", package = "OlinkAnalyze", mustWork = T)
-  manifest_file <- system.file("extdata", "npx_data1_meta.csv", package = "OlinkAnalyze", mustWork = T)
+  npx_file <- system.file("extdata", "npx_data1.xlsx", package = "OlinkAnalyze", mustWork = TRUE)
+  manifest_file <- system.file("extdata", "npx_data1_meta.csv", package = "OlinkAnalyze", mustWork = TRUE)
   df_1 <- read_NPX(filename = npx_file) # load dataset 1
-  manifest_1 <- read.delim(manifest_file, header = T, sep = ';') # load manifest 1
+  manifest_1 <- read.delim(manifest_file, header = TRUE, sep = ';') # load manifest 1
 
   #NPX read ok?
   expect(exists("df_1"), failure_message = "read_NPX failed on dataset 1")

--- a/OlinkAnalyze/tests/testthat/test-pca_plot.R
+++ b/OlinkAnalyze/tests/testthat/test-pca_plot.R
@@ -5,12 +5,12 @@ load(refRes_file)
 
 pca_plot <- npx_data1 %>%
   mutate(SampleID = paste(SampleID, "_", Index, sep = "")) %>%
-  olink_pca_plot(quiet = T)
+  olink_pca_plot(quiet = TRUE)
 
 pca_plot_treatCol <- npx_data1 %>%
   mutate(SampleID = paste(SampleID, "_", Index, sep = "")) %>%
   filter(!is.na(Treatment)) %>% #Or else, a warning shows up in the test results
-  olink_pca_plot(color_g = 'Treatment', quiet = T)
+  olink_pca_plot(color_g = 'Treatment', quiet = TRUE)
 
 pca_plot_treatCol_topLoadings <- npx_data1 %>%
   mutate(SampleID = paste(SampleID, "_", Index, sep = "")) %>%
@@ -19,17 +19,17 @@ pca_plot_treatCol_topLoadings <- npx_data1 %>%
                  loadings_list = {ref_results$t.test_results %>%
                      head(5) %>%
                      pull(OlinkID)},
-                 quiet = T)
+                 quiet = TRUE)
 
 #PCA by panel
 pca_plot_byPanel <- npx_data1 %>%
   mutate(SampleID = paste(SampleID, "_", Index, sep = "")) %>%
-  olink_pca_plot(byPanel = T, quiet = T)
+  olink_pca_plot(byPanel = TRUE, quiet = TRUE)
 
 #Label outliers
 pca_plot_byPanel_outliers <- npx_data1 %>%
   mutate(SampleID = paste(SampleID, "_", Index, sep = "")) %>%
-  olink_pca_plot(byPanel = T, outlierDefX = 4, outlierDefY = 2.5, quiet = T)
+  olink_pca_plot(byPanel = TRUE, outlierDefX = 4, outlierDefY = 2.5, quiet = TRUE)
 outliers <- lapply(pca_plot_byPanel_outliers, function(x){x$data}) %>%
   bind_rows() %>%
   filter(Outlier == 1)
@@ -41,7 +41,7 @@ test_that("olink_pca_plot works", {
     expect_warning(
       pca_plot_drop <- npx_data1 %>%
       mutate(SampleID = paste(SampleID, "_", Index, sep = "")) %>%
-      olink_pca_plot(drop_assays = TRUE, drop_samples = TRUE, quiet = T)
+      olink_pca_plot(drop_assays = TRUE, drop_samples = TRUE, quiet = TRUE)
     )
   )
 

--- a/OlinkAnalyze/vignettes/Vignett.Rmd
+++ b/OlinkAnalyze/vignettes/Vignett.Rmd
@@ -272,7 +272,7 @@ A tibble with the following columns:
 
 The olink_anova is a wrapper function that performs an ANOVA F-test for each assay using the function *Anova* from the R library *car* and Type III sum of squares. The function handles both factor and numerical variables, and/or confounding factors. 
 
-Samples with missing variable information or factor levels are excluded from the analysis. Character columns in the input data frame are converted to factors. The automatic handling of the data from above is announced by a message if the flag *verbose=T*.
+Samples with missing variable information or factor levels are excluded from the analysis. Character columns in the input data frame are converted to factors. The automatic handling of the data from above is announced by a message if the flag *verbose=TRUE*.
 
 Crossed/interaction analysis, i.e. A*B formula notation, is inferred from the variable argument in the following cases: 
 
@@ -280,9 +280,9 @@ Crossed/interaction analysis, i.e. A*B formula notation, is inferred from the va
 * c('A:B')
 * c('A:B', 'B') or c('A:B', 'A')
 
-Inference is specified in a message if *verbose=T*.
+Inference is specified in a message if *verbose=TRUE*.
 
-For covariates, crossed analyses need to be specified explicitly, i.e. two main effects will not be expanded with a c('A','B') notation. Main effects present in the variable take precedence. The formula notation of the final model is specified in a message if *verbose=T*. 
+For covariates, crossed analyses need to be specified explicitly, i.e. two main effects will not be expanded with a c('A','B') notation. Main effects present in the variable take precedence. The formula notation of the final model is specified in a message if *verbose=TRUE*. 
 
 Adjusted p-values are calculated using the function *p.adjust* from the R library *stats* with the Benjamini & Hochberg (1995) method (“fdr”). The threshold is determined by logic evaluation of Adjusted_pval < 0.05. Covariates are not included in the p-value adjustment.
 
@@ -339,7 +339,7 @@ The function handles both factor and numerical variables and/or covariates. The 
 * covariates: Single character value or character array. Default: NULL. Confounding factors to include in the analysis. In case of single character then that should represent a column in the df. It can also accept the notations ':' or '*', while crossed analysis will not be inferred from main effects.
 * outcome: Name of the column from df that contains the dependent variable. Default: NPX.
 * effect: Term on which to perform the post-hoc analysis. Character vector. Must be subset of or identical to the variable and no adjustment is performed.
-* mean_return: Logical. If true, returns the mean of each factor level rather than the difference in means (default). Note that no p-value is returned for mean_return = T.
+* mean_return: Logical. If true, returns the mean of each factor level rather than the difference in means (default). Note that no p-value is returned for mean_return = TRUE.
 * verbose: Logical. Default: True. If information about removed samples, factor conversion and final model formula is to be printed to the console.
 
 ```{r message=FALSE, eval=FALSE}
@@ -376,7 +376,7 @@ A tibble with the following columns:
 
 The olink_lmer fits a linear mixed effects model for every protein (by OlinkID) in every panel, using the function *lmer* from the R library *lmerTest* and the function *anova* from the R library *stats*. The function handles both factor and numerical variables and/or covariates.
 
-Samples with missing variable information or factor levels are excluded from the analysis. Character columns in the input data frame are converted to factors. The automatic handling of the data from above is announced by a message if the flag *verbose=T*. 
+Samples with missing variable information or factor levels are excluded from the analysis. Character columns in the input data frame are converted to factors. The automatic handling of the data from above is announced by a message if the flag *verbose=TRUE*. 
 
 Crossed/interaction analysis, i.e. A*B formula notation, is inferred from the variable argument in the following cases: 
 
@@ -384,9 +384,9 @@ Crossed/interaction analysis, i.e. A*B formula notation, is inferred from the va
 * c('A:B')
 * c('A:B', 'B') or c('A:B', 'A')
 
-Inference is specified in a message if *verbose=T*.
+Inference is specified in a message if *verbose=TRUE*.
 
-For covariates, crossed analyses need to be specified explicitly, i.e. two main effects will not be expanded with a c('A','B') notation. Main effects present in the variable take precedence. The formula notation of the final model is specified in a message if *verbose=T*.  
+For covariates, crossed analyses need to be specified explicitly, i.e. two main effects will not be expanded with a c('A','B') notation. Main effects present in the variable take precedence. The formula notation of the final model is specified in a message if *verbose=TRUE*.  
 
 Adjusted p-values are calculated using the function *p.adjust* from the R library *stats* with the Benjamini & Hochberg (1995) method (“fdr”). The threshold is determined by logic evaluation of Adjusted_pval < 0.05. Covariates are not included in the p-value adjustment.
 
@@ -442,7 +442,7 @@ The olink_lmer_posthoc function is similar to olink_lmer but performs a post-hoc
 * outcome: Name of the column from df that contains the dependent variable. Default: NPX.
 * random: Single character value or character array with random effects.
 * covariates: Single character value or character array. Default: NULL. Confounding factors to include in the analysis. In case of single character then that should represent a column in the df. It can also accept the notations ':' or '*', while crossed analysis will not be inferred from main effects.
-* mean_return: Logical. If true, returns the mean of each factor level rather than the difference in means (default). Note that no p-value is returned for mean_return = T and no adjustment is performed.
+* mean_return: Logical. If true, returns the mean of each factor level rather than the difference in means (default). Note that no p-value is returned for mean_return = TRUE and no adjustment is performed.
 * verbose: Logical. Default: True. If information about removed samples, factor conversion and final model formula is to be printed to the console.
 
 ```{r message=FALSE, eval=FALSE}
@@ -593,18 +593,18 @@ The arguments outlierDefX and outlierDefY can be used to identify outliers in th
 npx_data1 %>% 
   filter(!str_detect(SampleID, 'CONTROL_SAMPLE')) %>% 
   olink_pca_plot(df = .,
-                 color_g = "QC_Warning", byPanel = T)  
+                 color_g = "QC_Warning", byPanel = TRUE)  
 ```
 
 ### Function output
 
 A list of objects of class *ggplot* (silently returned). Plots are also printed unless option `quiet = TRUE` is set. If outlierDefX and outlierDefY are specified, a list of outliers can be extracted from the **ggplot** object based on these parameters.
 
-```{r message = F}
+```{r message = FALSE}
 npx_data <- npx_data1 %>%
     mutate(SampleID = paste(SampleID, "_", Index, sep = ""))
 g <- olink_pca_plot(df=npx_data, color_g = "QC_Warning",
-                    outlierDefX = 2.5, outlierDefY = 4, byPanel = TRUE, quiet = T)
+                    outlierDefX = 2.5, outlierDefY = 4, byPanel = TRUE, quiet = TRUE)
 lapply(g, function(x){x$data}) %>%
   bind_rows() %>%
   filter(Outlier == 1) %>% 
@@ -640,7 +640,7 @@ npx_data1 %>%
 
 An object of class *ggplot*. A list of outliers can be extracted from the **ggplot** object.
 
-```{r message = F}
+```{r message = FALSE}
 qc <- olink_qc_plot(npx_data1, color_g = "QC_Warning", IQR_outlierDef = 3, median_outlierDef = 3)
 qc$data %>% filter(Outlier == 1) %>% select(SampleID, Panel, IQR, sample_median, Outlier)
 ```


### PR DESCRIPTION
Improves consistency and prevents problems if T or F are used as variable names.