### PR TITLE
Specifically skip long running tests on CRAN

### DIFF
--- a/OlinkAnalyze/tests/testthat.R
+++ b/OlinkAnalyze/tests/testthat.R
@@ -1,8 +1,7 @@
 library(testthat)
 library(OlinkAnalyze)
 
-if (length(strsplit(as.character(packageVersion("OlinkAnalyze")), "\\.")) > 3){
-  test_check("OlinkAnalyze")
-}
+test_check("OlinkAnalyze")
+
 
 

--- a/OlinkAnalyze/tests/testthat/test-Olink_boxplot.R
+++ b/OlinkAnalyze/tests/testthat/test-Olink_boxplot.R
@@ -1,3 +1,5 @@
+skip_on_cran()
+
 #Load reference results
 refRes_file <- '../data/refResults.RData'
 load(refRes_file)

--- a/OlinkAnalyze/tests/testthat/test-linear_mixed_model.R
+++ b/OlinkAnalyze/tests/testthat/test-linear_mixed_model.R
@@ -1,3 +1,5 @@
+skip_on_cran()
+
 #Load reference results
 refRes_file <- '../data/refResults.RData'
 load(refRes_file)

--- a/OlinkAnalyze/tests/testthat/test-olink_Pathway_Enrichment.R
+++ b/OlinkAnalyze/tests/testthat/test-olink_Pathway_Enrichment.R
@@ -1,3 +1,6 @@
+skip_on_cran()
+skip_if_not_installed("clusterProfiler")
+
 npx_df <- npx_data1 %>%
   dplyr::filter(!stringr::str_detect(SampleID, "CONTROL"))
 ttest_results <- olink_ttest(df = npx_df, variable = "Treatment")


### PR DESCRIPTION
# Title: Skip long running tests on CRAN
**Problem:** CRAN does not allow long running tests to be run on their cluster

**Solution:** This PR skips long running tests, in particular pathway enrichment tests on CRAN to reduce the time needed for testing our submission

This should make the quickfix introduced previously unnecessary

## Checklist
- [X] Make sure you are requesting to **pull a feature/bugfix branch** (right side). This should not be main or develop.
- [X] Make sure you are make a pull request against either **main or develop** (left side). (Requesting to main should be reserved for bugfixes and new releases)
- [ ] Add or update unit tests (if applicable)
- [ ] Check your code with any unit tests (Run devtools::check() locally)
- [ ] Add neccessary documentation (if applicable)

## Type of changes

What type of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue) (link the issue on the right)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Documentation Update 
- [ ] Other (explain)

