### PR TITLE
New data support

### DIFF
--- a/OlinkAnalyze/DESCRIPTION
+++ b/OlinkAnalyze/DESCRIPTION
@@ -97,4 +97,4 @@ VignetteBuilder:
 Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.2

--- a/OlinkAnalyze/R/Read_NPX_data.R
+++ b/OlinkAnalyze/R/Read_NPX_data.R
@@ -219,6 +219,7 @@ read_NPX_explore <- function(filename) {
 read_NPX_target <- function(filename) {
 
   NORM_FLAG <-  FALSE
+  long_form <- FALSE
 
   # Check if the data is npx or concentration as well as if it is T48 or T96
 
@@ -230,7 +231,7 @@ read_NPX_target <- function(filename) {
                                   range = 'G2',
                                   col_names = FALSE,
                                   .name_repair = "minimal")
-
+  
   if (grepl(pattern = 'NPX', x = data_type, fixed = TRUE)) {
 
     is_npx_data     <- TRUE
@@ -257,7 +258,7 @@ read_NPX_target <- function(filename) {
     BASE_INDEX      <- 45
   } else if (grepl(pattern = "Target", data_type_long, fixed = TRUE)){
     message("Target Data in long form detected.")
-    long_form = TRUE
+    long_form <- TRUE
   } else {
     stop("Cannot find whether the given data is NPX or concentration")
   }

--- a/OlinkAnalyze/R/Read_NPX_data.R
+++ b/OlinkAnalyze/R/Read_NPX_data.R
@@ -169,14 +169,15 @@ read_NPX_explore <- function(filename) {
 
 
   # Check that all column names are present
-  # We have had 3 column names versions so far: 1, 1.1 and 2
+  # We have had 5 column names versions so far: 1, 1.1 and 2, 2.1, and 3
   # please add newer versions to the list chronologically
   header_standard <-    c("SampleID", "Index", "OlinkID", "UniProt", "Assay", "MissingFreq",
                           "Panel", "PlateID", "QC_Warning", "LOD", "NPX")
   header_v        <- list("header_v1"   = c(header_standard, "Panel_Version"),
                           "header_v1.1" = c(header_standard, "Panel_Version", "Normalization", "Assay_Warning"),
                           "header_v2"   = c(header_standard, "Panel_Lot_Nr", "Normalization", "Assay_Warning"),
-                          "header_v2.1" = c(header_standard, "Panel_Lot_Nr", "Normalization"))
+                          "header_v2.1" = c(header_standard, "Panel_Lot_Nr", "Normalization"),
+                          "header_v3" = c(header_standard, "Sample_Type", "Panel_Lot_Nr", "Normalization", "ExploreVersion"))
   header_match    <-  any( sapply(header_v, function(x) all(x %in% colnames(out))) ) # look for one full match
 
   if (header_match == TRUE) {

--- a/OlinkAnalyze/R/Read_NPX_data.R
+++ b/OlinkAnalyze/R/Read_NPX_data.R
@@ -296,6 +296,7 @@ read_NPX_target <- function(filename) {
                     dplyr::matches("Normalization"),
                     dplyr::matches("*Inc Ctrl*"),
                     dplyr::matches("*Det Ctrl*"))
+    is_npx_data <- ifelse(any(names(out) %in% "NPX"), TRUE, FALSE)
   } else {
     # Load initial meta data (the first rows of the wide file)
     meta_dat <-  readxl::read_excel(path = filename,

--- a/OlinkAnalyze/R/Read_NPX_data.R
+++ b/OlinkAnalyze/R/Read_NPX_data.R
@@ -177,8 +177,16 @@ read_NPX_explore <- function(filename) {
                           "header_v1.1" = c(header_standard, "Panel_Version", "Normalization", "Assay_Warning"),
                           "header_v2"   = c(header_standard, "Panel_Lot_Nr", "Normalization", "Assay_Warning"),
                           "header_v2.1" = c(header_standard, "Panel_Lot_Nr", "Normalization"),
-                          "header_v3" = c(header_standard, "Sample_Type", "Panel_Lot_Nr", "Normalization", "ExploreVersion"))
+                          "header_v3" = c(header_standard, "Sample_Type", "Panel_Lot_Nr", "Assay_Warning",
+                                          "Normalization", "ExploreVersion"))
   header_match    <-  any( sapply(header_v, function(x) all(x %in% colnames(out))) ) # look for one full match
+  if (any(names(out) %in% c("Sample_Type", "ExploreVersion" ))){
+    missing_cols<-setdiff(c("Sample_Type", "ExploreVersion" ), names(out))
+    if(length(missing_cols) != 0){
+      stop(paste0("Cannot find columns: ", paste(missing_cols, collapse = ",")))
+    }
+    
+  }
 
   if (header_match == TRUE) {
 

--- a/OlinkAnalyze/R/Read_NPX_data.R
+++ b/OlinkAnalyze/R/Read_NPX_data.R
@@ -1,9 +1,9 @@
 #' Function to read NPX data into long format
 #'
-#' Imports an NPX file exported from NPX Manager or MyData.
-#' No alterations to the output NPX Manager format is allowed.
+#' Imports an NPX file exported from Olink Software.
+#' No alterations to the output format is allowed.
 #'
-#' @param filename Path to NPX Manager or MyData output file.
+#' @param filename Path to Olink Software output file.
 #' @return A "tibble" in long format. Columns include:
 #' \itemize{
 #'    \item{SampleID:} Sample ID

--- a/OlinkAnalyze/R/Read_NPX_data.R
+++ b/OlinkAnalyze/R/Read_NPX_data.R
@@ -272,6 +272,7 @@ read_NPX_target <- function(filename) {
       dplyr::mutate(Panel =  gsub("\\(.*\\)","",Panel)) %>%
       dplyr::mutate(Panel = stringr::str_to_title(Panel)) %>%
       dplyr::mutate(Panel = gsub("Target 96", "", Panel)) %>%
+      dplyr::mutate(Panel = gsub("Target 48", "", Panel)) %>%
       dplyr::mutate(Panel = gsub("Olink", "", Panel)) %>%
       dplyr::mutate(Panel = trimws(Panel, which = "left")) %>%
       tidyr::separate(Panel, " ", into = c("Panel_Start", "Panel_End"), fill = "right") %>%
@@ -529,6 +530,7 @@ read_NPX_target <- function(filename) {
       dplyr::mutate(Panel =  gsub("\\(.*\\)","",Panel)) %>%
       dplyr::mutate(Panel = stringr::str_to_title(Panel)) %>%
       dplyr::mutate(Panel = gsub("Target 96", "", Panel)) %>%
+      dplyr::mutate(Panel = gsub("Target 48", "", Panel)) %>%
       dplyr::mutate(Panel = gsub("Olink", "", Panel)) %>%
       dplyr::mutate(Panel = trimws(Panel, which = "left")) %>%
       tidyr::separate(Panel, " ", into = c("Panel_Start", "Panel_End"), fill = "right") %>%

--- a/OlinkAnalyze/man/read_NPX.Rd
+++ b/OlinkAnalyze/man/read_NPX.Rd
@@ -7,7 +7,7 @@
 read_NPX(filename)
 }
 \arguments{
-\item{filename}{Path to NPX Manager or MyData output file.}
+\item{filename}{Path to Olink Software output file.}
 }
 \value{
 A "tibble" in long format. Columns include:
@@ -27,8 +27,8 @@ A "tibble" in long format. Columns include:
 Additional columns may be present or missing depending on the platform
 }
 \description{
-Imports an NPX file exported from NPX Manager or MyData.
-No alterations to the output NPX Manager format is allowed.
+Imports an NPX file exported from Olink Software.
+No alterations to the output format is allowed.
 }
 \examples{
 \donttest{


### PR DESCRIPTION
# Title: Edits to read_NPX to support additional Olink data file format types
**Problem:** Currently long target data and data with additional column names arent supported

**Solution:** Created a new if statement in read_target_data where if G2 (Panel Name) contains Target, then the data is assumed to be in long format and is read in directly and formated/checked as in wide format data. Additionally new Explore columns in version 3 were added.

**Key Features:**

* Can read in long format Target 96 and Target 48 data
* Target 48 is removed from panel names
* New column names (sample_type, ExploreVersion) are explicitly supported

I checked this function with some data that Jes sent. 

## Checklist
- [x] Make sure you are requesting to **pull a feature/bugfix branch** (right side). This should not be main or develop.
- [x] Make sure you are make a pull request against either **main or develop** (left side). (Requesting to main should be reserved for bugfixes and new releases)
- [ ] Add or update unit tests (if applicable)
- [x] Check your code with any unit tests (Run devtools::check() locally)
- [ ] Add neccessary documentation (if applicable)

## Type of changes

What type of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue) (link the issue on the right)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Documentation Update 
- [ ] Other (explain)

## Further comments
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, any questions you have, etc...

Consider linking any issues (#issue-number ) or adding @mentions to ensure specific people see it.
