### PR TITLE
ORA non matching genes message (OA-282)

### DIFF
--- a/OlinkAnalyze/R/olink_Pathway_Enrichment.R
+++ b/OlinkAnalyze/R/olink_Pathway_Enrichment.R
@@ -166,7 +166,7 @@ data_prep <- function(data) {
   # Remove NA data and filter for valid Olink IDs
   npx_check <- npxCheck(data)
   data <- data %>%
-    dplyr::filter(!(OlinkID %in% npx_check$all_nas)) %>% 
+    dplyr::filter(!(OlinkID %in% npx_check$all_nas)) %>%
     dplyr::filter(stringr::str_detect(OlinkID,
                                       "OID[0-9]{5}"))
   # Filter highest detectibility for repeated IDs
@@ -263,10 +263,10 @@ ora_pathwayenrichment <- function(test_results, msig_df, pvalue_cutoff = pvalue_
     dplyr::distinct(Assay) %>%
     dplyr::pull(Assay)
 
-  if(length(setdiff(names(universe), msig_df$gene_symbol) != 0)){
-    message(paste0(length(setdiff(names(universe), msig_df$gene_symbol)),
+  if(length(setdiff(universe, msig_df$gene_symbol) != 0)){
+    message(paste0(length(setdiff(universe, msig_df$gene_symbol)),
                    " assays are not found in the database. Please check the Assay names for the following assays:\n ",
-                   toString(setdiff(names(universe), msig_df$gene_symbol))))
+                   toString(setdiff(universe, msig_df$gene_symbol))))
   }
 
   ORA <- clusterProfiler::enricher(gene = sig_genes, universe = universe, TERM2GENE = msig_df, pvalueCutoff = 1)


### PR DESCRIPTION
# Title: Write a very short summary here
**Problem:** ORA does not print the name of non matching genes message.

**Solution:** `names(universe)` is `null`. Replaced it with `universe`.



## Checklist
- [x] Make sure you are requesting to **pull a feature/bugfix branch** (right side). This should not be main or develop.
- [x] Make sure you are make a pull request against either **main or develop** (left side). (Requesting to main should be reserved for bugfixes and new releases)
- [x] Add or update unit tests (if applicable)
- [x] Check your code with any unit tests (Run devtools::check() locally)
- [x] Add necessary documentation (if applicable)

## Type of changes

What type of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue) (link the issue on the right)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Documentation Update 
- [ ] Other (explain)

## Further comments
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, any questions you have, etc...

Consider linking any issues (#issue-number ) or adding @mentions to ensure specific people see it.
