### PR TITLE
Tests are handling {pillar} 1.9.0 output now

### DIFF
--- a/OlinkAnalyze/tests/testthat/_snaps/Read_NPX_data.md
+++ b/OlinkAnalyze/tests/testthat/_snaps/Read_NPX_data.md
@@ -9,7 +9,4 @@
       1 sample1_1     1 OID20070 O43186  CRX           0 Card~ B04405  full_2~ PASS   
       2 sample2_1     2 OID20070 O43186  CRX           0 Card~ B04405  full_2~ PASS   
       3 sample3_1     3 OID20070 O43186  CRX           0 Card~ B04405  full_2~ PASS   
-      # ... with 4 more variables: LOD <dbl>, NPX <dbl>, Normalization <chr>,
-      #   Assay_Warning <chr>, and abbreviated variable names 1: MissingFreq,
-      #   2: Panel_Lot_Nr, 3: QC_Warning
 

--- a/OlinkAnalyze/tests/testthat/setup.R
+++ b/OlinkAnalyze/tests/testthat/setup.R
@@ -1,0 +1,1 @@
+options(pillar.min_title_chars = 5, pillar.max_footer_lines = 0)


### PR DESCRIPTION
# Title: Tests are handling {pillar} 1.9.0 output now
**Problem:** [{pillar} 1.9.0](https://pillar.r-lib.org/news/index.html#printing-1-9-0) changed the output format slightly. This made snapshot tests fail

**Solution:** Set options for test runs to be less dependent on changing {pillar} defaults and update snapshots to new output

## Checklist
- [X] Make sure you are requesting to **pull a feature/bugfix branch** (right side). This should not be main or develop.
- [X] Make sure you are make a pull request against either **main or develop** (left side). (Requesting to main should be reserved for bugfixes and new releases)
- [X] Add or update unit tests (if applicable)
- [X] Check your code with any unit tests (Run devtools::check() locally)
- [ ] Add neccessary documentation (if applicable)

## Type of changes

What type of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue) (link the issue on the right)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Documentation Update 
- [X] Other: CI

