### PR TITLE
Deprecate the use of Ubuntu 18.04 images in CI

### DIFF
--- a/.github/workflows/matrix_config_check.json
+++ b/.github/workflows/matrix_config_check.json
@@ -15,12 +15,6 @@
       "runOn": "always"
    },
    {
-      "os": "ubuntu-18.04",
-      "r": "release",
-      "runOn": "pull_request",
-      "comment": "This is included since the UKBB platform runs Ubuntu 18.04"
-   },   
-   {
       "os": "ubuntu-20.04",
       "r": "devel",
       "runOn": "pull_request"


### PR DESCRIPTION
# Title: Deprecate the use of Ubuntu 18.04 images in CI
**Problem:** Ubuntu 18.04 images are not available any longer for CI runners on github: https://github.com/actions/runner-images/issues/6002

**Solution:** Remove the use of that image

## Checklist
- [X] Make sure you are requesting to **pull a feature/bugfix branch** (right side). This should not be main or develop.
- [X] Make sure you are make a pull request against either **main or develop** (left side). (Requesting to main should be reserved for bugfixes and new releases)
- [ ] Add or update unit tests (if applicable)
- [ ] Check your code with any unit tests (Run devtools::check() locally)
- [ ] Add neccessary documentation (if applicable)

## Type of changes

What type of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue) (link the issue on the right)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Documentation Update 
- [X] Other (explain): CI

