### PR TITLE
Fix issue OA-252

### DIFF
--- a/OlinkAnalyze/tests/testthat/test-Olink_bridgeselector.R
+++ b/OlinkAnalyze/tests/testthat/test-Olink_bridgeselector.R
@@ -14,3 +14,14 @@ test_that("olink_bridgeselector works", {
                                     n = 8))
   expect_warning(olink_bridgeselector(npx_data_format221010, sampleMissingFreq = 0.1, n = 2))
 })
+
+test_that("olink_bridgeselector max num of samples works", {
+  expect_equal(
+    {
+      olink_bridgeselector(df = npx_data1,
+                           sampleMissingFreq = 0.1,
+                           n = 150) |>
+        nrow()
+    },
+    150)
+})


### PR DESCRIPTION
# Title
This PR is expected to fix a bug in the olink bridge selector function (#252 ).

**Problem:**
Olink bridge selector returns 1 sample fewer than expected when asked to return x samples, and exactly x samples from the dataset satisfy the selection criteria.

**Solution:**
We force the function to return all samples that satisfy the selection criteria in that number equals the number of requested bridge samples.

## Checklist
- [X] Make sure you are requesting to **pull a feature/bugfix branch** (right side). This should not be main or develop.
- [X] Make sure you are make a pull request against either **main or develop** (left side). (Requesting to main should be reserved for bugfixes and new releases)
- [X] Add or update unit tests (if applicable)
- [X] Check your code with any unit tests (Run devtools::check() locally)
- [ ] Add neccessary documentation (if applicable)

## Type of changes

What type of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue) (#252 )
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Documentation Update 
- [ ] Other (explain)

## Further comments
@kathy-nevola shall we include this in the fixes for v 3.4? I would yes as it fixes a bug already reported by a customer. If yes, can please someone review?

**Note** that currently tests are failing because of the fix from (#250 ) is not merge here yet.
