### PR TITLE
Check that parquet's metadata contains required fields

### DIFF
--- a/OlinkAnalyze/R/read_npx_parquet.R
+++ b/OlinkAnalyze/R/read_npx_parquet.R
@@ -41,12 +41,30 @@ read_npx_parquet <- function (filename) {
     sources = filename
   )
 
+  # Check that parquet metadat is in place
+  olink_parquet_metadata <- c("DataFileType",
+                              "ProductType")
+  if (!all(olink_parquet_metadata %in% names(parquet_file$metadata))) {
+
+    stop(
+      paste("Missing required fileds",
+            paste(
+              paste0("\"", olink_parquet_metadata, "\""),
+              collapse = " and "),
+            "in parquet file's metadata."
+            )
+      )
+
+  }
+
   # We allow only Olink Explore HT parquet files for now
   # If other platforms are to be reported as parquet too, we have to add
   # them to this array
   olink_platforms <- c("ExploreHT")
   if (!(parquet_file$metadata$ProductType %in% olink_platforms)) {
+
     stop("Only \"Olink Explore HT\" parquet files are currently supported.")
+
   }
 
 

--- a/OlinkAnalyze/R/read_npx_parquet.R
+++ b/OlinkAnalyze/R/read_npx_parquet.R
@@ -41,7 +41,7 @@ read_npx_parquet <- function (filename) {
     sources = filename
   )
 
-  # Check that parquet metadata is in place
+  # Check that all required parquet metadata is in place
   olink_parquet_metadata <- c("DataFileType",
                               "ProductType")
   if (!all(olink_parquet_metadata %in% names(parquet_file$metadata))) {

--- a/OlinkAnalyze/R/read_npx_parquet.R
+++ b/OlinkAnalyze/R/read_npx_parquet.R
@@ -41,7 +41,7 @@ read_npx_parquet <- function (filename) {
     sources = filename
   )
 
-  # Check that parquet metadat is in place
+  # Check that parquet metadata is in place
   olink_parquet_metadata <- c("DataFileType",
                               "ProductType")
   if (!all(olink_parquet_metadata %in% names(parquet_file$metadata))) {


### PR DESCRIPTION
# Title: Check that parquet's metadata contains required fields
**Problem:** When custom parquet files are provided as input, the error thrown by the read_npx_parquet function was not very intuitive.

**Solution:** Added metadata fields that are explicitly required in the parquet file.

## Checklist
- [X] Make sure you are requesting to **pull a feature/bugfix branch** (right side). This should not be main or develop.
- [X] Make sure you are make a pull request against either **main or develop** (left side). (Requesting to main should be reserved for bugfixes and new releases)
- [ ] Add or update unit tests (if applicable)
- [X] Check your code with any unit tests (Run devtools::check() locally)
- [ ] Add neccessary documentation (if applicable)

## Type of changes

What type of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue) (link the issue on the right)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Documentation Update 
- [ ] Other (explain)

## Further comments
No large changes made. Just a more explicit error handling.
