### PR TITLE
Oa 421 Subset Example to filter out samples that dont pass in all assays

### DIFF
--- a/OlinkAnalyze/R/Olink_normalization.R
+++ b/OlinkAnalyze/R/Olink_normalization.R
@@ -58,13 +58,15 @@
 #' # Find a suitable subset of samples from both projects, but exclude Olink controls
 #' # and samples which do not pass QC.
 #' df1_sampleIDs <- npx_df1 %>%
-#'     dplyr::filter(QC_Warning == 'Pass') %>%
+#'     dplyr::group_by(SampleID) %>%
+#'     dplyr::filter(all(QC_Warning == 'Pass')) %>%
 #'     dplyr::filter(!stringr::str_detect(SampleID, 'CONTROL_SAMPLE')) %>%
 #'     dplyr::select(SampleID) %>%
 #'     unique() %>%
 #'     dplyr::pull(SampleID)
 #' df2_sampleIDs <- npx_df2 %>%
-#'     dplyr::filter(QC_Warning == 'Pass') %>%
+#'     dplyr::group_by(SampleID) %>%
+#'     dplyr::filter(all(QC_Warning == 'Pass')) %>%
 #'     dplyr::filter(!stringr::str_detect(SampleID, 'CONTROL_SAMPLE')) %>%
 #'     dplyr::select(SampleID) %>%
 #'     unique() %>%

--- a/OlinkAnalyze/R/olink_normalization_n.R
+++ b/OlinkAnalyze/R/olink_normalization_n.R
@@ -124,13 +124,15 @@
 #' # controls and samples that fail QC.
 #' df1_samples <- npx_df1 |>
 #'   dplyr::filter(!stringr::str_detect(SampleID, "CONTROL_")) |>
-#'   dplyr::filter(QC_Warning == 'Pass') |>
+#'   dplyr::group_by(SampleID) |>
+#'   dplyr::filter(all(QC_Warning == 'Pass')) |>
 #'   dplyr::pull(SampleID) |>
 #'   unique() |>
 #'   sample(size = 16, replace = FALSE)
 #' df2_samples <- npx_df2 |>
 #'   dplyr::filter(!stringr::str_detect(SampleID, "CONTROL_")) |>
-#'   dplyr::filter(QC_Warning == 'Pass') |>
+#'   dplyr::group_by(SampleID) |>
+#'   dplyr::filter(all(QC_Warning == 'Pass')) |>
 #'   dplyr::pull(SampleID) |>
 #'   unique() |>
 #'   sample(size = 16, replace = FALSE)
@@ -170,10 +172,14 @@
 #' # controls and samples that fail QC.
 #' df1_samples_all <- npx_df1 |>
 #'   dplyr::filter(!stringr::str_detect(SampleID, "CONTROL_")) |>
+#'   dplyr::group_by(SampleID) |>
+#'   dplyr::filter(all(QC_Warning == 'Pass')) |>
 #'   dplyr::pull(SampleID) |>
 #'   unique()
 #' df2_samples_all <- npx_df2 |>
 #'   dplyr::filter(!stringr::str_detect(SampleID, "CONTROL_")) |>
+#'   dplyr::group_by(SampleID) |>
+#'   dplyr::filter(all(QC_Warning == 'Pass')) |>
 #'   dplyr::pull(SampleID) |>
 #'   unique()
 #'
@@ -593,13 +599,15 @@ olink_normalization_bridge <- function(project_1_df,
 #' # controls and samples that fail QC.
 #' df1_samples <- npx_df1 |>
 #'   dplyr::filter(!stringr::str_detect(SampleID, "CONTROL_")) |>
-#'   dplyr::filter(QC_Warning == 'Pass') |>
+#'   dplyr::group_by(SampleID) |>
+#'   dplyr::filter(all(QC_Warning == 'Pass')) |>
 #'   dplyr::pull(SampleID) |>
 #'   unique() |>
 #'   sample(size = 16, replace = FALSE)
 #' df2_samples <- npx_df2 |>
 #'   dplyr::filter(!stringr::str_detect(SampleID, "CONTROL_")) |>
-#'   dplyr::filter(QC_Warning == 'Pass') |>
+#'   dplyr::group_by(SampleID) |>
+#'   dplyr::filter(all(QC_Warning == 'Pass')) |>
 #'   dplyr::pull(SampleID) |>
 #'   unique() |>
 #'   sample(size = 16, replace = FALSE)
@@ -633,10 +641,14 @@ olink_normalization_bridge <- function(project_1_df,
 #' # controls and samples that fail QC.
 #' df1_samples_all <- npx_df1 |>
 #'   dplyr::filter(!stringr::str_detect(SampleID, "CONTROL_")) |>
+#'   dplyr::group_by(SampleID) |>
+#'   dplyr::filter(all(QC_Warning == 'Pass')) |>
 #'   dplyr::pull(SampleID) |>
 #'   unique()
 #' df2_samples_all <- npx_df2 |>
 #'   dplyr::filter(!stringr::str_detect(SampleID, "CONTROL_")) |>
+#'   dplyr::group_by(SampleID) |>
+#'   dplyr::filter(all(QC_Warning == 'Pass')) |>
 #'   dplyr::pull(SampleID) |>
 #'   unique()
 #'

--- a/OlinkAnalyze/man/olink_normalization.Rd
+++ b/OlinkAnalyze/man/olink_normalization.Rd
@@ -82,13 +82,15 @@ olink_normalization(df1 = npx_df1,
 # Find a suitable subset of samples from both projects, but exclude Olink controls
 # and samples which do not pass QC.
 df1_sampleIDs <- npx_df1 \%>\%
-    dplyr::filter(QC_Warning == 'Pass') \%>\%
+    dplyr::group_by(SampleID) \%>\%
+    dplyr::filter(all(QC_Warning == 'Pass')) \%>\%
     dplyr::filter(!stringr::str_detect(SampleID, 'CONTROL_SAMPLE')) \%>\%
     dplyr::select(SampleID) \%>\%
     unique() \%>\%
     dplyr::pull(SampleID)
 df2_sampleIDs <- npx_df2 \%>\%
-    dplyr::filter(QC_Warning == 'Pass') \%>\%
+    dplyr::group_by(SampleID) \%>\%
+    dplyr::filter(all(QC_Warning == 'Pass')) \%>\%
     dplyr::filter(!stringr::str_detect(SampleID, 'CONTROL_SAMPLE')) \%>\%
     dplyr::select(SampleID) \%>\%
     unique() \%>\%

--- a/OlinkAnalyze/man/olink_normalization_n.Rd
+++ b/OlinkAnalyze/man/olink_normalization_n.Rd
@@ -130,13 +130,15 @@ npx_df2 <- npx_data2 |>
 # controls and samples that fail QC.
 df1_samples <- npx_df1 |>
   dplyr::filter(!stringr::str_detect(SampleID, "CONTROL_")) |>
-  dplyr::filter(QC_Warning == 'Pass') |>
+  dplyr::group_by(SampleID) |>
+  dplyr::filter(all(QC_Warning == 'Pass')) |>
   dplyr::pull(SampleID) |>
   unique() |>
   sample(size = 16, replace = FALSE)
 df2_samples <- npx_df2 |>
   dplyr::filter(!stringr::str_detect(SampleID, "CONTROL_")) |>
-  dplyr::filter(QC_Warning == 'Pass') |>
+  dplyr::group_by(SampleID) |>
+  dplyr::filter(all(QC_Warning == 'Pass')) |>
   dplyr::pull(SampleID) |>
   unique() |>
   sample(size = 16, replace = FALSE)
@@ -176,10 +178,14 @@ npx_df2 <- npx_data2 |>
 # controls and samples that fail QC.
 df1_samples_all <- npx_df1 |>
   dplyr::filter(!stringr::str_detect(SampleID, "CONTROL_")) |>
+  dplyr::group_by(SampleID) |>
+  dplyr::filter(all(QC_Warning == 'Pass')) |>
   dplyr::pull(SampleID) |>
   unique()
 df2_samples_all <- npx_df2 |>
   dplyr::filter(!stringr::str_detect(SampleID, "CONTROL_")) |>
+  dplyr::group_by(SampleID) |>
+  dplyr::filter(all(QC_Warning == 'Pass')) |>
   dplyr::pull(SampleID) |>
   unique()
 

--- a/OlinkAnalyze/man/olink_normalization_subset.Rd
+++ b/OlinkAnalyze/man/olink_normalization_subset.Rd
@@ -72,13 +72,15 @@ npx_df2 <- npx_data2 |>
 # controls and samples that fail QC.
 df1_samples <- npx_df1 |>
   dplyr::filter(!stringr::str_detect(SampleID, "CONTROL_")) |>
-  dplyr::filter(QC_Warning == 'Pass') |>
+  dplyr::group_by(SampleID) |>
+  dplyr::filter(all(QC_Warning == 'Pass')) |>
   dplyr::pull(SampleID) |>
   unique() |>
   sample(size = 16, replace = FALSE)
 df2_samples <- npx_df2 |>
   dplyr::filter(!stringr::str_detect(SampleID, "CONTROL_")) |>
-  dplyr::filter(QC_Warning == 'Pass') |>
+  dplyr::group_by(SampleID) |>
+  dplyr::filter(all(QC_Warning == 'Pass')) |>
   dplyr::pull(SampleID) |>
   unique() |>
   sample(size = 16, replace = FALSE)
@@ -112,10 +114,14 @@ npx_df2 <- npx_data2 |>
 # controls and samples that fail QC.
 df1_samples_all <- npx_df1 |>
   dplyr::filter(!stringr::str_detect(SampleID, "CONTROL_")) |>
+  dplyr::group_by(SampleID) |>
+  dplyr::filter(all(QC_Warning == 'Pass')) |>
   dplyr::pull(SampleID) |>
   unique()
 df2_samples_all <- npx_df2 |>
   dplyr::filter(!stringr::str_detect(SampleID, "CONTROL_")) |>
+  dplyr::group_by(SampleID) |>
+  dplyr::filter(all(QC_Warning == 'Pass')) |>
   dplyr::pull(SampleID) |>
   unique()
 

--- a/OlinkAnalyze/vignettes/Vignett.Rmd
+++ b/OlinkAnalyze/vignettes/Vignett.Rmd
@@ -221,13 +221,15 @@ olink_normalization(df1 = npx_data1,
 
 # Example of using all samples for normalization
 subset_df1 <- npx_data1 %>% 
-  filter(QC_Warning == 'Pass') %>% 
+  group_by(SampleID) %>%
+  filter(all(QC_Warning == 'Pass')) %>% 
   filter(!str_detect(SampleID, 'CONTROL_SAMPLE')) %>%
   pull(SampleID) %>% 
   unique()
 
-subset_df2 <- npx_data2 %>% 
-  filter(QC_Warning == 'Pass') %>% 
+subset_df2 <- npx_data2 %>%   
+  group_by(SampleID) %>%
+  filter(all(QC_Warning == 'Pass')) %>% 
   filter(!str_detect(SampleID, 'CONTROL_SAMPLE')) %>%
   pull(SampleID) %>% 
   unique()


### PR DESCRIPTION
# Title:  Subset Documentation Fix for QC Filtering
**Problem:** Currently subset normalization uses filter for QC_Warning == PASS to generate a list of samples for the subset. However this method would only exclude samples that fail in all assays, instead of only including  samples that pass in all assays. We need to update:
- Vignette
- Olink_normalization
- olink_normalization_subset
- olink_normalization_n

**Solution:** Replaced QC_Warning=="Pass" filter with:
`dplyr::group_by(SampleID) |>
 dplyr::filter(all(QC_Warning == 'Pass')) |>`

for all subset and examples
**Key Features:**
Updates to:
- Vignette
- Olink_normalization
- olink_normalization_subset
- olink_normalization_n

## Checklist
- [x] Make sure you are requesting to **pull a feature/bugfix branch** (right side). This should not be main or develop.
- [x] Make sure you are make a pull request against either **main or develop** (left side). (Requesting to main should be reserved for bugfixes and new releases)
- [ ] Add or update unit tests (if applicable) -> N/A
- [ ] Check your code with any unit tests (Run devtools::check() locally)
- [x] Add neccessary documentation (if applicable)

## Type of changes

What type of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue) (link the issue on the right)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [x] Documentation Update 
- [ ] Other (explain)

## Further comments
** Question: previously the all sample version of subset normalization didnt have filtering for QC warning, but did have a comment that said to filter our QC warning samples. I have added the code to reflect this comment. Is this correct? Or does the comment need to be changed instead?**
