### PR TITLE
OA-47 Clarifying how to perform randomization for longitudinal datasets

### DIFF
--- a/OlinkAnalyze/R/Olink_plate_randomizer.R
+++ b/OlinkAnalyze/R/Olink_plate_randomizer.R
@@ -216,7 +216,7 @@ generatePlateHolder <- function(n.plates,n.spots,n.samples, PlateSize, num_ctrl,
 #' @param Manifest tibble/data frame in long format containing all sample ID's. Sample ID column must be named SampleID.
 #' @param PlateSize Integer. Either 96 or 48. 96 is default.
 #' @param Product String. Name of Olink product used to set PlateSize if not provided. Optional.
-#' @param SubjectColumn (Optional) Column name of the subject ID column. Cannot contain missings. If provided, subjects are kept on the same plate.
+#' @param SubjectColumn (Optional) Column name of the subject ID column. Cannot contain missing values. If provided, subjects are kept on the same plate. This argument is used for longitudinal studies and must be a separate column from the SampleID column.
 #' @param iterations Number of iterations for fitting subjects on the same plate.
 #' @param available.spots Numeric. Number of wells available on each plate. Maximum 40 for T48 and 88 for T96. Takes a vector equal to the number of plates to be used indicating the number of wells available on each plate.
 #' @param num_ctrl Numeric. Number of controls on each plate (default = 8)
@@ -242,7 +242,7 @@ generatePlateHolder <- function(n.plates,n.spots,n.samples, PlateSize, num_ctrl,
 #' #Generate randomization scheme using complete randomization
 #' randomized.manifest_a <- olink_plate_randomizer(manifest, seed=12345)
 #'
-#' #Generate randomization scheme that keeps subjects on the same plate
+#' #Generate randomization scheme that keeps subjects on the same plate (for longitudinal studies)
 #' randomized.manifest_b <- olink_plate_randomizer(manifest,SubjectColumn="SubjectID",
 #'                                                         available.spots=c(88,88), seed=12345)
 #'

--- a/OlinkAnalyze/man/olink_plate_randomizer.Rd
+++ b/OlinkAnalyze/man/olink_plate_randomizer.Rd
@@ -23,7 +23,7 @@ olink_plate_randomizer(
 
 \item{Product}{String. Name of Olink product used to set PlateSize if not provided. Optional.}
 
-\item{SubjectColumn}{(Optional) Column name of the subject ID column. Cannot contain missings. If provided, subjects are kept on the same plate.}
+\item{SubjectColumn}{(Optional) Column name of the subject ID column. Cannot contain missing values. If provided, subjects are kept on the same plate. This argument is used for longitudinal studies and must be a separate column from the SampleID column.}
 
 \item{iterations}{Number of iterations for fitting subjects on the same plate.}
 
@@ -56,7 +56,7 @@ Variables of interest should if possible be randomized across plates to avoid co
 #Generate randomization scheme using complete randomization
 randomized.manifest_a <- olink_plate_randomizer(manifest, seed=12345)
 
-#Generate randomization scheme that keeps subjects on the same plate
+#Generate randomization scheme that keeps subjects on the same plate (for longitudinal studies)
 randomized.manifest_b <- olink_plate_randomizer(manifest,SubjectColumn="SubjectID",
                                                         available.spots=c(88,88), seed=12345)
 

--- a/OlinkAnalyze/vignettes/Vignett.Rmd
+++ b/OlinkAnalyze/vignettes/Vignett.Rmd
@@ -147,14 +147,14 @@ The olink_plate_randomizer function randomly assigns samples to a plate well wit
 
 + Manifest: tibble/data frame in long format containing all sample ID's. Sample ID column should be named SampleID.
 + PlateSize: Integer, either 96 or 48. 96 is default and should be used for Olink® Target 96 and Olink® Explore projects. For Olink® Target 48 projects, use 48.
-+ SubjectColumn: (Optional) Column name of the subject ID column. Cannot contain missing values. If provided, subjects are kept on the same plate.
++ SubjectColumn: (Optional) Column name of the subject ID column. Cannot contain missing values. If provided, subjects are kept on the same plate. This argument is used for longitudinal studies and must be a separate column from the SampleID column.
 + iterations: Number of iterations for fitting subjects on the same plate.
 + available.spots: (Optional) Integer. Number of wells available on each plate. Maximum 40 for Olink® Target 48 and 88 for Olink® Target 96/Explore. Can also take a vector equal to the number of plates to be used indicating the number of wells available on each plate.
 + seed: Seed to set. Highly recommend setting it for reproducibility.
 
 ```{r message=FALSE, eval=FALSE}
 olink_plate_randomizer(manifest, 
-                       SubjectColumn ="SampleID",
+                       SubjectColumn ="SubjectID",
                        seed=111)
 ```  
 

--- a/OlinkAnalyze/vignettes/plate_randomizer.Rmd
+++ b/OlinkAnalyze/vignettes/plate_randomizer.Rmd
@@ -68,7 +68,9 @@ randomized.manifest <- olink_plate_randomizer(manifest, seed=123456)
 
 ### Generate randomization scheme that keeps subjects on the same plate
 
-In the case of multiple samples per subject (e.g. in longitudinal studies), Olink recommends keeping each subject on the same plate to further reduce variation in the data. The individuals should then be distributed so that the remaining experimental variables of interest are evenly distributed across plates. This could be achieved by using the `SubjectColumn` argument. However, if there are to many samples per subject (>8), complete randomization is recommended. The number of samples on each plate could be specified via the `available.spots` argument. For example, the following code will lead to 78 samples on the first plate, and 30 samples on the second and the third plates. The number of iterations for fitting subjects on the same plate can be set by the `iterations` argument. 
+In the case of multiple samples per subject (e.g. in longitudinal studies), Olink recommends keeping each subject on the same plate to further reduce variation in the data. The individuals should then be distributed so that the remaining experimental variables of interest are evenly distributed across plates. This could be achieved by using the `SubjectColumn` argument. The `SubjectColumn` argument must correspond to a column within the manifest and cannot be SampleID. If `SubjectColumn` is specified, every SampleID must have a value in the subject column, even if there is only 1 sample for that subject. 
+
+However, if there are to many samples per subject (>8), complete randomization is recommended. The number of samples on each plate could be specified via the `available.spots` argument. For example, the following code will lead to 78 samples on the first plate, and 30 samples on the second and the third plates. The number of iterations for fitting subjects on the same plate can be set by the `iterations` argument. 
 
 
 ```{r subjects_randomization, message=FALSE,results='hide'}


### PR DESCRIPTION
# Title: Clarifying plate randomizer documentation
**Problem:** My only recommendation to prevent future confusion for others doing longitudinal plating designs would be to include some type of note in the package help file specifying that both SampleID and SubjectID need to be separate columns in the Manifest data frame. Alternatively, maybe an input for the longitudinal indicator (e.g., “visit”) in the function. It may only be me, but I was completely lost on this issue until I saw inputs for several of the Olink functions used within olink_plate_randomizer.

**Solution:** Clarified longitudinal randomization across documentation in function and vignettes. Fixed example in vignette. 


## Checklist
- [x] Make sure you are requesting to **pull a feature/bugfix branch** (right side). This should not be main or develop.
- [X] Make sure you are making a pull request against either **main or develop** (left side). (Requesting to main should be reserved for bugfixes and new releases)
- [ ] Add or update unit tests (if applicable) -> NA
- [ ] Check your code with any unit tests (Run devtools::check() locally) -> NA
- [X] Add necessary documentation (if applicable)

## Type of changes

What type of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue) (link the issue on the right)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [X] Documentation Update 
- [ ] Other (explain)

## Further comments
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, any questions you have, etc...

Consider linking any issues (#issue-number ) or adding @mentions to ensure specific people see it.
