### PR TITLE
Fix regex to recognize older data as T96

### DIFF
--- a/OlinkAnalyze/R/Read_NPX_data.R
+++ b/OlinkAnalyze/R/Read_NPX_data.R
@@ -326,15 +326,19 @@ read_NPX_target <- function(filename) {
     isTarget96 <- TRUE
     isFlex <- FALSE
 
-  } else if (any(stringr::str_detect(c(panel_name, panel_name_long), pattern = "[A-Z]{4}-[A-Z]{4} || Flex"))){
+  } else if (any(stringr::str_detect(c(panel_name, panel_name_long), pattern = "[A-Z]{4}-[A-Z]{4}|Flex"))){
 
     isTarget48 <- FALSE
     isTarget96 <- FALSE
     isFlex <- TRUE
 
+  } else if(any(stringr::str_detect(c(panel_name, panel_name_long), pattern = "Olink"))){
+    isTarget48 <- FALSE
+    isTarget96 <- TRUE
+    isFlex <- FALSE
   } else {
 
-    stop("Cannot detect if Target or Flex.")
+    stop("Cannot detect if Target or Flex. Note: Data exported from NPXS 1.8+ is only supported in long format csv.")
 
   }
 


### PR DESCRIPTION
# Title: Adding back support for older data
**Problem:** New version of function expects Target 96, Target 48, or flex format to be in panel name. Older data only contained Olink in panel name + an extra "|" was added in Flex regex causing all old files to be read as Flex data and would convert LOD and missing freq to samples. 

**Solution:** Extra pipe was removed from Flex regex and additional if statement was added to capture older data panel formats and recognize them as T96.

**Key Features:**

* Older data where panel is "Olink xxxxx" is now recognized as T96 data not flex
* New data still works  (all tests pass)

## Checklist
- [x] Make sure you are requesting to **pull a feature/bugfix branch** (right side). This should not be main or develop.
- [x] Make sure you are make a pull request against either **main or develop** (left side). (Requesting to main should be reserved for bugfixes and new releases)
- [ ] Add or update unit tests (if applicable)
- [x] Check your code with any unit tests (Run devtools::check() locally)
- [x] Add neccessary documentation (if applicable)

## Type of changes

What type of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue) (link the issue on the right)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Documentation Update 
- [ ] Other (explain)

## Further comments
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, any questions you have, etc...

Consider linking any issues (#issue-number ) or adding @mentions to ensure specific people see it.
