### PR TITLE
Patch to allow for arrow to be used after it is removed from CRAN

### DIFF
--- a/OlinkAnalyze/DESCRIPTION
+++ b/OlinkAnalyze/DESCRIPTION
@@ -109,3 +109,4 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.2.3
+Additional_repositories: https://p3m.dev/cran/2024-02-02

--- a/OlinkAnalyze/R/read_npx_parquet.R
+++ b/OlinkAnalyze/R/read_npx_parquet.R
@@ -33,7 +33,8 @@ read_npx_parquet <- function (filename) {
     stop("Reading parquet files requires the arrow package.
          Please install arrow before continuing.
 
-         install.packages(\"arrow\")")
+         install.packages(lib = \"arrow\",
+         repos = \"https://p3m.dev/cran/2024-02-02\")")
   }
 
   # pointer to parquet file


### PR DESCRIPTION
# Title: Patch to allow for arrow to be used after it is removed from CRAN

**Problem:** Arrow will de removed from CRAN soon (Feb 9) which means that it might cause issues with OA.

**Solution:** Following suggestions from https://github.com/apache/arrow/issues/39806#issuecomment-1928098252 to add an additional repository in DESCRIPTION file.

## Checklist
- [X] Make sure you are requesting to **pull a feature/bugfix branch** (right side). This should not be main or develop.
- [X] Make sure you are make a pull request against either **main or develop** (left side). (Requesting to main should be reserved for bugfixes and new releases)
- [ ] Add or update unit tests (if applicable)
- [X] Check your code with any unit tests (Run devtools::check() locally)
- [ ] Add neccessary documentation (if applicable)

## Type of changes

What type of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue) (link the issue on the right)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Documentation Update 
- [ ] Other (explain)

## Further comments
This is not an issue for now and we should not merge it unless CRAN removes OA. I am confident that the arrow team will have the package back to CRAN very soon, so we might not need to merge this PR.
