### PR TITLE
Clarify excluding controls as bridge samples

### DIFF
--- a/OlinkAnalyze/vignettes/bridging_introduction.Rmd
+++ b/OlinkAnalyze/vignettes/bridging_introduction.Rmd
@@ -95,7 +95,7 @@ from the reference study and be added to the second study. These samples
 can be selected using the `olink_bridgeselector()` function in Olink
 Analyze. The bridge selection function will select a number of bridge
 samples based on the reference data. This function selects samples which
-passes QC and have high detectibility. In the case of where detectibility cannot be calculated from the test data set (ex: Explore HT data), the function will only select samples which pass QC. External controls are not selected as bridge samples as they are not necessarily representative of the study and therefore may not cover the dynamic range of assays that would be expressed within the samples.
+passes QC and have high detectibility. In the case of where detectibility cannot be calculated from the test data set (ex: Explore HT data), the function will only select samples which pass QC. External controls are not selected as bridge samples as they are not necessarily representative of the study and therefore may not cover the dynamic range of assays that would be expressed within the samples. Note that due to naming convention differences, it is necessary to exclude the control samples using either `SampleType == "SAMPLE"` if available or `stringr::str_detect()` as shown below.
 
 To select samples across the range of the data, the samples are ordered by mean NPX value and selected across this range. When running the selector, Olink recommends starting at sampleMissingFreq = 0.10 which represents a maximum of 10% data below LOD per sample. If there are not enough samples output, increase to 20%. For alternative matrices and specific disease types, it may be needed to increase the sampleMissingFreq to higher levels.
 
@@ -104,14 +104,18 @@ In this example we will demonstrate how to select 16 bridging samples
 using `npx_data1` which will act as the reference data. The selected bridge samples are displayed in Table 2.
 
 ```{r bridge_sample_selection_example, echo=T, eval=T}
-bridge_Samples<-olink_bridgeselector(df = npx_data1,
-                     sampleMissingFreq = 0.1,
+
+bridge_Samples<- npx_data1 %>% 
+  # Excluding control samples. Naming convention may differ.
+  dplyr::filter((stringr::str_detect(SampleID, "CONTROL", negate = TRUE))) %>%
+  olink_bridgeselector(sampleMissingFreq = 0.1,
                      n = 16)
 ```
 
 ```{r bridge_sample_selection, echo=FALSE}
-olink_bridgeselector(df = npx_data1,
-                     sampleMissingFreq = 0.1,
+npx_data1 %>% 
+  filter((stringr::str_detect(SampleID, "CONTROL", negate = TRUE))) %>%
+  olink_bridgeselector(sampleMissingFreq = 0.1,
                      n = 16) %>%
   kableExtra::kbl(booktabs = TRUE,
       digits = 2,


### PR DESCRIPTION
# Title: Control Samples need to be excluded before bridge sample selection
**Problem:**  While there is a statement in olink_bridgeselector() to remove control samples, due to naming sample conventions, they will not always be removed, which can be confusing to users. 

**Solution:** Additional text and example code was added to the bridging tutorial to clarify that control samples should be removed and how to remove them


## Checklist
- [x] Make sure you are requesting to **pull a feature/bugfix branch** (right side). This should not be main or develop.
- [x] Make sure you are make a pull request against either **main or develop** (left side). (Requesting to main should be reserved for bugfixes and new releases)
- [ ] Add or update unit tests (if applicable)
- [ ] Check your code with any unit tests (Run devtools::check() locally)
- [x] Add neccessary documentation (if applicable)

## Type of changes

What type of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue) (link the issue on the right)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [x] Documentation Update 
- [ ] Other (explain)

## Further comments
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, any questions you have, etc...

Consider linking any issues (#issue-number ) or adding @mentions to ensure specific people see it.
