### PR TITLE
Bug fix for "Note" in devtools::check()

### DIFF
--- a/OlinkAnalyze/DESCRIPTION
+++ b/OlinkAnalyze/DESCRIPTION
@@ -53,9 +53,6 @@ Description: A collection of functions to facilitate analysis of proteomic
     package is to help users extract biological insights from proteomic
     data run on the Olink platform.
 License: AGPL (>= 3)
-VignetteBuilder: 
-  kableExtra,
-  knitr
 Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true

--- a/OlinkAnalyze/DESCRIPTION
+++ b/OlinkAnalyze/DESCRIPTION
@@ -62,8 +62,6 @@ Imports:
     arrow,
     cli,
     dplyr,
-    kableExtra,
-    knitr,
     readxl,
     rlang,
     stringr,


### PR DESCRIPTION
# Title: Bug fix for "Note" in devtools::check()
**Problem:** When running devtools::check() there would be a Note about the R libraries knitr and kableExtra.

**Solution:** Removed both packages from DESCRIPTION

## Checklist
- [X] Make sure you are requesting to **pull a feature/bugfix branch** (right side). This should not be main or develop.
- [X] Make sure you are make a pull request against either **main or develop** (left side). (Requesting to main should be reserved for bugfixes and new releases)
- [ ] Add or update unit tests (if applicable)
- [X] Check your code with any unit tests (Run devtools::check() locally)
- [ ] Add neccessary documentation (if applicable)

## Type of changes

What type of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue) (link the issue on the right)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [X] Documentation Update 
- [ ] Other (explain)