### PR TITLE
NPXS <1.8 multiplate Flex bugfix

### DIFF
--- a/OlinkAnalyze/R/read_flex.R
+++ b/OlinkAnalyze/R/read_flex.R
@@ -150,7 +150,7 @@ read_flex <- function(filename) {
   
   # pivot longer
   dat<- dat |> 
-    dplyr::filter(!str_detect(SampleID, paste( "Missing Data freq.",
+    dplyr::filter(!stringr::str_detect(SampleID, paste("Missing Data freq.",
                                                "Normalization",
                                                "Assay warning",
                                                "Lowest quantifiable level",
@@ -158,12 +158,12 @@ read_flex <- function(filename) {
                                                "LLOQ",
                                                "ULOQ",
                                                "LOD", 
-                                               collapse = "|"))) |>  # remove end meta data
+                                               sep = "|"))) |>  # remove end meta data
     tidyr::pivot_longer(cols = tidyselect::starts_with("OID"),
                         names_to = "OlinkID",
                         values_to = ifelse(is_npx_data, "NPX", "Quantified_value")) |> 
     dplyr::left_join(metadata, by = c("OlinkID")) |> 
-    dplyr::left_join(meta_data_per_assay, by = "OlinkID", multiple = "all") |> 
+    dplyr::left_join(meta_data_per_assay, by = c("OlinkID", "PlateID1"), multiple = "all") |> 
     dplyr::mutate(PlateID = PlateID1) |> 
     dplyr::mutate(QC_Warning = QC_Warning1) |> 
     dplyr::select(SampleID, OlinkID,


### PR DESCRIPTION
# Title: Support for wide format multiplate flex data (pre-NPXS 1.8)
**Problem:** Wide format Flex data (pre NPXS 1.8 which should be supported) was not working with read_NPX in multiplate projects

**Solution:** Two bugs were found and addressed in read_flex: 
* When filtering out metadata (line 153) in the paste call, collapse was changed to sep (line 161) to correctly form the logical argument.
* When joining the per assay meta data, plateID was included as a merging column as some assay meta data differs between plates (line 166)


## Checklist
- [x] Make sure you are requesting to **pull a feature/bugfix branch** (right side). This should not be main or develop.
- [x] Make sure you are make a pull request against either **main or develop** (left side). (Requesting to main should be reserved for bugfixes and new releases)
- [ ] Add or update unit tests (if applicable)
- [ ] Check your code with any unit tests (Run devtools::check() locally)
- [ ] Add neccessary documentation (if applicable)

## Type of changes

What type of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue) (link the issue on the right)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Documentation Update 
- [ ] Other (explain)

## Further comments
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, any questions you have, etc...

Consider linking any issues (#issue-number ) or adding @mentions to ensure specific people see it.
