### PR TITLE
add quote argument to ignore assays with "'" (OA-172)

### DIFF
--- a/OlinkAnalyze/R/read_npx_csv.R
+++ b/OlinkAnalyze/R/read_npx_csv.R
@@ -33,6 +33,7 @@ read_npx_csv <- function(filename) {
     file = filename,
     header = TRUE,
     sep = ";",
+    quote = "",
     stringsAsFactors = FALSE,
     na.strings = c("NA", ""),
     comment.char = ""

--- a/OlinkAnalyze/tests/testthat/refs/mock_sampleID_hashes.csv
+++ b/OlinkAnalyze/tests/testthat/refs/mock_sampleID_hashes.csv
@@ -1,3 +1,3 @@
-"";"SampleID";"Index";"OlinkID";"UniProt";"Assay";"MissingFreq";"Panel";"Panel_Lot_Nr";"PlateID";"QC_Warning";"LOD";"NPX";"Normalization";"Assay_Warning"
-"1";"Sample#1";1;"OID31158";"Q96KB5";"PBK";"0.1";"Oncology_II";"B22604";"Project_test_hash";"PASS";-1;1;"Plate control";"WARN"
-"2";"Sample_#31";2;"OID31158";"Q96KB5";"PBK";"0.1";"Oncology_II";"B22604";"Project_test_hash";"PASS";-1;11;"Plate control";"WARN"
+SampleID;Index;OlinkID;UniProt;Assay;MissingFreq;Panel;Panel_Lot_Nr;PlateID;QC_Warning;LOD;NPX;Normalization;Assay_Warning
+Sample#1;1;OID31158;Q96KB5;PBK;0.1;Oncology_II;B22604;Project_test_hash;PASS;-1;1;Plate control;WARN
+Sample_#31;2;OID31158;Q96KB5;PBK;0.1;Oncology_II;B22604;Project_test_hash;PASS;-1;11;Plate control;WARN


### PR DESCRIPTION
# Title: add quote argument to ignore assays with "'" 
**Problem:** Current version of read_NPX causes issues with long csvs including 5'-NT assay

**Solution:** Add quote argument to remove default " ' " character

**Key Features:**

* Key feature 1
* Key feature 2
* ...

## Checklist
- [ ] Make sure you are requesting to **pull a feature/bugfix branch** (right side). This should not be main or develop.
- [ ] Make sure you are make a pull request against either **main or develop** (left side). (Requesting to main should be reserved for bugfixes and new releases)
- [ ] Add or update unit tests (if applicable)
- [ ] Check your code with any unit tests (Run devtools::check() locally)
- [ ] Add neccessary documentation (if applicable)

## Type of changes

What type of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue) (link the issue on the right)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Documentation Update 
- [ ] Other (explain)

## Further comments
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, any questions you have, etc...

Consider linking any issues (#issue-number ) or adding @mentions to ensure specific people see it.
