### PR TITLE
Additional CSV support ( OA-2270 and OA-2151 )

### DIFF
--- a/OlinkAnalyze/R/Read_NPX_data.R
+++ b/OlinkAnalyze/R/Read_NPX_data.R
@@ -76,8 +76,10 @@ read_NPX_explore <- function(filename) {
   # Check that all column names are present
   # We have had 5 column names versions so far: 1, 1.1 and 2, 2.1, and 3
   # please add newer versions to the list chronologically
-  header_standard <- c("SampleID", "OlinkID", "UniProt", "Assay",
-                       "Panel", "PlateID", "QC_Warning", "NPX")
+  header_base <- c("SampleID", "OlinkID", "UniProt", "Assay",
+                       "Panel", "PlateID", "NPX")
+  
+  header_standard <- c(header_base, "QC_Warning")
 
   header_quant_standard <- c("SampleID", "OlinkID", "UniProt", "Assay",
                        "Panel", "PlateID", "QC_Warning")
@@ -190,7 +192,41 @@ read_NPX_explore <- function(filename) {
                              "PlateLOD",
                              "QC.Deviation.Inc.Ctrl",
                              "QC.Deviation.Det.Ctrl",
-                             "Olink.NPX.Signature.Version")
+                             "Olink.NPX.Signature.Version"),
+    "header_csv_hp" = c(header_base,
+                        "SampleType",
+                        "WellID",
+                        "DataAnalysisRefID",
+                        "AssayType",
+                        "Block",
+                        "Counts",
+                        "ExtNPX",
+                        "Normalization",
+                        "PCNormalizedNPX",
+                        "AssayQC",
+                        "SampleQC",
+                        "SoftwareVersion",
+                        "SoftwareName"),
+    "header_ext_csv_hp" = c(header_base,
+                            "SampleType",
+                            "WellID",
+                            "DataAnalysisRefID",
+                            "AssayType",
+                            "Block",
+                            "Counts",
+                            "ExtNPX",
+                            "Normalization",
+                            "PCNormalizedNPX",
+                            "AssayQC",
+                            "SampleQC",
+                            "SoftwareVersion",
+                            "SoftwareName",
+                            "IntraCV",
+                            "InterCV",
+                            "SampleBlockQCWarn",
+                            "SampleBlockQCFail",
+                            "BlockQCFail",
+                            "AssayQCWarn")
 
   )
 

--- a/OlinkAnalyze/R/Read_NPX_data.R
+++ b/OlinkAnalyze/R/Read_NPX_data.R
@@ -284,6 +284,11 @@ read_NPX_explore <- function(filename) {
       dplyr::mutate(Panel = trimws(Panel, which = "right")) %>%
       dplyr::select(-Panel_Start, -Panel_End)
   }
+  if ("Quantified_value" %in% names(out)){
+    message("QUANT data detected. Some downstream functions may not be supported.")
+    out <- out %>%
+      mutate(Quantified_value = as.numeric(Quantified_value))
+  }
 
   return(out)
 

--- a/OlinkAnalyze/R/read_npx_csv.R
+++ b/OlinkAnalyze/R/read_npx_csv.R
@@ -47,6 +47,7 @@ read_npx_csv <- function(filename) {
       file = filename,
       header = TRUE,
       sep = ",",
+      quote = "",
       stringsAsFactors = FALSE,
       na.strings = c("NA", "")
     )

--- a/OlinkAnalyze/inst/extdata/Example_NPX_Data.csv
+++ b/OlinkAnalyze/inst/extdata/Example_NPX_Data.csv
@@ -1,2 +1,2 @@
-"","SampleID","Index","OlinkID","UniProt","Assay","MissingFreq","Panel","Panel_Version","PlateID","QC_Warning","LOD","NPX","Subject","Treatment","Site","Time","Project"
-"1","A1",1,"OID01216","O00533","CHL1",0.01875,"Olink CARDIOMETABOLIC","v.1201","Example_Data_1_CAM.csv","Pass",2.36846658156787,12.9561425886431,"ID1","Untreated","Site_D","Baseline","20200001"
+SampleID,Index,OlinkID,UniProt,Assay,MissingFreq,Panel,Panel_Version,PlateID,QC_Warning,LOD,NPX,Subject,Treatment,Site,Time,Project
+A1,1,OID01216,O00533,CHL1,0.01875,Olink CARDIOMETABOLIC,v.1201,Example_Data_1_CAM.csv,Pass,2.36846658156787,12.9561425886431,ID1,Untreated,Site_D,Baseline,P1


### PR DESCRIPTION
Additional support to read_NPX added for:

- Column headers with SampleQC instead of QC_Warning
- Ignoring quotes in csv with comma (previously implemented for semicolon delimited, see #381), required update to extdata, see below
- Add a warning message about lack of support for long format csv quant files

Additionally:

- removed row names from extdata/Example_NPX_Data.csv
- Changed project name to P1
- rewrote Example_NPX_Data.csv to remove quotes and rownames