### PR TITLE
Add an error ANOVA functions when control assays are present

### DIFF
--- a/OlinkAnalyze/R/Olink_anova.R
+++ b/OlinkAnalyze/R/Olink_anova.R
@@ -56,7 +56,7 @@
 #'
 #' library(dplyr)
 #'
-#' npx_df <- npx_data1 %>% filter(!grepl('control',SampleID, ignore.case = TRUE))
+#' npx_df <- npx_data1 %>% filter(!grepl('control|ctrl',SampleID, ignore.case = TRUE))
 #'
 #' #One-way ANOVA, no covariates.
 #' #Results in a model NPX~Time
@@ -140,8 +140,8 @@ olink_anova <- function(df,
     ctrl_samples <- df |>
       dplyr::filter(stringr::str_detect(df$SampleID, stringr::regex("control|ctrl", ignore_case = TRUE)))
     
-    stop(paste0(
-      'Control samples have not been removed from the dataset.\n  Samples with "control" or "ctrl" in their SampleID field should be excluded.\n  The following ', length(unique(ctrl_samples$SampleID)), " control samples were found:\n  ",
+    warning(paste0(
+      'Potential control samples detected in input data.\n  Samples with "control" or "ctrl" in their SampleID field were flagged as potential control samples. If these samples are controls they should be excluded.\n  The following ', length(unique(ctrl_samples$SampleID)), " potential control samples were found:\n  ",
       paste(strwrap(toString(unique(ctrl_samples$SampleID)), width = 80), collapse = "\n")
     ))
   }
@@ -391,7 +391,7 @@ olink_anova <- function(df,
 #'
 #' library(dplyr)
 #'
-#' npx_df <- npx_data1 %>% filter(!grepl('control',SampleID, ignore.case = TRUE))
+#' npx_df <- npx_data1 %>% filter(!grepl('control|ctrl',SampleID, ignore.case = TRUE))
 #'
 #' #Two-way ANOVA, one main effect (Site) covariate.
 #' #Results in model NPX~Treatment*Time+Site.
@@ -521,8 +521,8 @@ if ("SampleType" %in% names(df)) {
   ctrl_samples <- df |>
     dplyr::filter(stringr::str_detect(df$SampleID, stringr::regex("control|ctrl", ignore_case = TRUE)))
 
-  stop(paste0(
-    'Control samples have not been removed from the dataset.\n  Samples with "control" or "ctrl" in their SampleID field should be excluded.\n  The following ', length(unique(ctrl_samples$SampleID)), " control samples were found:\n  ",
+  warning(paste0(
+    'Potential control samples detected in input data.\n  Samples with "control" or "ctrl" in their SampleID field were flagged as potential control samples. If these samples are controls they should be excluded.\n  The following ', length(unique(ctrl_samples$SampleID)), " potential control samples were found:\n  ",
     paste(strwrap(toString(unique(ctrl_samples$SampleID)), width = 80), collapse = "\n")
   ))
 }

--- a/OlinkAnalyze/R/Olink_anova.R
+++ b/OlinkAnalyze/R/Olink_anova.R
@@ -113,7 +113,7 @@ olink_anova <- function(df,
     if (any(ctrl_types %in% df$AssayType)) {
       stop('Control assays have not been removed from the dataset.\n  Assays with AssayType != "assay" should be excluded.')
     }
-  } else if (any(str_detect(df$Assay, "control"))) {
+  } else if (any(str_detect(df$Assay, regex("control|ctrl", ignore_case = TRUE)))) {
     stop('Control assays have not been removed from the dataset.\n  Assays with "control" in their Assay field should be excluded.')
   }
   
@@ -461,7 +461,7 @@ olink_anova_posthoc <- function(df,
     if (any(ctrl_types %in% df$AssayType)) {
       stop('Control assays have not been removed from the dataset.\n  Assays with AssayType != "assay" should be excluded.')
     }
-  } else if (any(str_detect(df$Assay, "control"))) {
+  } else if (any(str_detect(df$Assay, regex("control|ctrl", ignore_case = TRUE)))) {
     stop('Control assays have not been removed from the dataset.\n  Assays with "control" in their Assay field should be excluded.')
   }
   

--- a/OlinkAnalyze/R/Olink_anova.R
+++ b/OlinkAnalyze/R/Olink_anova.R
@@ -5,7 +5,7 @@
 #'Samples that have no variable information or missing factor levels are automatically removed from the analysis (specified in a message if verbose = TRUE).
 #'Character columns in the input dataframe are automatically converted to factors (specified in a message if verbose = TRUE).
 #'Numerical variables are not converted to factors.
-#'Control samples (SampleType is not "SAMPLE, or SampleID contains "control" or "ctrl") should be removed before using this function.
+#'Control samples should be removed before using this function.
 #'Control assays (AssayType is not "assay", or Assay contains "control" or "ctrl") should be removed before using this function.
 #'If a numerical variable is to be used as a factor, this conversion needs to be done on the dataframe before the function call. \cr\cr
 #'Crossed analysis, i.e. A*B formula notation, is inferred from the variable argument in the following cases: \cr
@@ -330,7 +330,7 @@ olink_anova <- function(df,
 #'Performs a post hoc ANOVA test using emmeans::emmeans with Tukey p-value adjustment per assay (by OlinkID) for each panel at confidence level 0.95.
 #'See \code{olink_anova} for details of input notation. \cr\cr
 #'The function handles both factor and numerical variables and/or covariates.
-#'Control samples (SampleType is not "SAMPLE, or SampleID contains "control" or "ctrl") should be removed before using this function.
+#'Control samples should be removed before using this function.
 #'Control assays (AssayType is not "assay", or Assay contains "control" or "ctrl") should be removed before using this function.
 #'The posthoc test for a numerical variable compares the difference in means of the outcome variable (default: NPX) for 1 standard deviation difference in the numerical variable, e.g.
 #'mean NPX at mean(numerical variable) versus mean NPX at mean(numerical variable) + 1*SD(numerical variable).

--- a/OlinkAnalyze/R/Olink_anova.R
+++ b/OlinkAnalyze/R/Olink_anova.R
@@ -125,26 +125,6 @@ olink_anova <- function(df,
                 paste(strwrap(toString(unique(ctrl_assays$Assay)), width = 80), collapse = "\n")))
   }
   
-  # Stop if external controls (samples) have not been removed
-  if ("SampleType" %in% names(df)) {
-    if (any(df$SampleType != "SAMPLE")) {
-      ctrl_samples <- df |>
-        dplyr::filter(SampleType != "SAMPLE")
-      
-      stop(paste0(
-        'Control samples have not been removed from the dataset.\n  Samples with SampleType != "SAMPLE" should be excluded.\n  The following ', length(unique(ctrl_samples$SampleID)), " control samples were found:\n  ",
-        paste(strwrap(toString(unique(ctrl_samples$SampleID)), width = 80), collapse = "\n")
-      ))
-    }
-  } else if (any(stringr::str_detect(df$SampleID, stringr::regex("control|ctrl", ignore_case = TRUE)))) {
-    ctrl_samples <- df |>
-      dplyr::filter(stringr::str_detect(df$SampleID, stringr::regex("control|ctrl", ignore_case = TRUE)))
-    
-    warning(paste0(
-      'Potential control samples detected in input data.\n  Samples with "control" or "ctrl" in their SampleID field were flagged as potential control samples. If these samples are controls they should be excluded.\n  The following ', length(unique(ctrl_samples$SampleID)), " potential control samples were found:\n  ",
-      paste(strwrap(toString(unique(ctrl_samples$SampleID)), width = 80), collapse = "\n")
-    ))
-  }
   
   withCallingHandlers({
     
@@ -506,26 +486,6 @@ olink_anova_posthoc <- function(df,
     ))
   }
 
-# Stop if external controls (samples) have not been removed
-if ("SampleType" %in% names(df)) {
-  if (any(df$SampleType != "SAMPLE")) {
-    ctrl_samples <- df |>
-      dplyr::filter(SampleType != "SAMPLE")
-
-    stop(paste0(
-      'Control samples have not been removed from the dataset.\n  Samples with SampleType != "SAMPLE" should be excluded.\n  The following ', length(unique(ctrl_samples$SampleID)), " control samples were found:\n  ",
-      paste(strwrap(toString(unique(ctrl_samples$SampleID)), width = 80), collapse = "\n")
-    ))
-  }
-} else if (any(stringr::str_detect(df$SampleID, stringr::regex("control|ctrl", ignore_case = TRUE)))) {
-  ctrl_samples <- df |>
-    dplyr::filter(stringr::str_detect(df$SampleID, stringr::regex("control|ctrl", ignore_case = TRUE)))
-
-  warning(paste0(
-    'Potential control samples detected in input data.\n  Samples with "control" or "ctrl" in their SampleID field were flagged as potential control samples. If these samples are controls they should be excluded.\n  The following ', length(unique(ctrl_samples$SampleID)), " potential control samples were found:\n  ",
-    paste(strwrap(toString(unique(ctrl_samples$SampleID)), width = 80), collapse = "\n")
-  ))
-}
   
   withCallingHandlers({
     

--- a/OlinkAnalyze/R/Olink_anova.R
+++ b/OlinkAnalyze/R/Olink_anova.R
@@ -106,8 +106,19 @@ olink_anova <- function(df,
     stop('The df and variable arguments need to be specified.')
   }
 
-  withCallingHandlers({
+  # Stop if control assays have not been removed
+  ctrl_types <- c("amp_ctrl", "ext_ctrl", "inc_ctrl")
 
+  if ("AssayType" %in% names(df)) {
+    if (any(ctrl_types %in% df$AssayType)) {
+      stop('Control assays have not been removed from the dataset.\n  Assays with AssayType != "assay" should be excluded.')
+    }
+  } else if (any(str_detect(df$Assay, "control"))) {
+    stop('Control assays have not been removed from the dataset.\n  Assays with "control" in their Assay field should be excluded.')
+  }
+  
+  withCallingHandlers({
+    
     #Filtering on valid OlinkID
     df <- df %>%
       dplyr::filter(stringr::str_detect(OlinkID,
@@ -443,9 +454,19 @@ olink_anova_posthoc <- function(df,
     stop("All effect terms must be included in the variable argument or model formula.")
   }
 
+  # Stop if control assays have not been removed
+  ctrl_types <- c("amp_ctrl", "ext_ctrl", "inc_ctrl")
 
+  if ("AssayType" %in% names(df)) {
+    if (any(ctrl_types %in% df$AssayType)) {
+      stop('Control assays have not been removed from the dataset.\n  Assays with AssayType != "assay" should be excluded.')
+    }
+  } else if (any(str_detect(df$Assay, "control"))) {
+    stop('Control assays have not been removed from the dataset.\n  Assays with "control" in their Assay field should be excluded.')
+  }
+  
   withCallingHandlers({
-
+    
     #Filtering on valid OlinkID
     df <- df %>%
       dplyr::filter(stringr::str_detect(OlinkID,

--- a/OlinkAnalyze/R/Olink_anova.R
+++ b/OlinkAnalyze/R/Olink_anova.R
@@ -107,14 +107,20 @@ olink_anova <- function(df,
   }
 
   # Stop if control assays have not been removed
-  ctrl_types <- c("amp_ctrl", "ext_ctrl", "inc_ctrl")
-
   if ("AssayType" %in% names(df)) {
-    if (any(ctrl_types %in% df$AssayType)) {
-      stop('Control assays have not been removed from the dataset.\n  Assays with AssayType != "assay" should be excluded.')
+    if (any(df$AssayType != "assay")) {
+      ctrl_assays <- df |>
+        dplyr::filter(AssayType != "assay")
+      
+      stop(paste0('Control assays have not been removed from the dataset.\n  Assays with AssayType != "assay" should be excluded.\n  The following control assays were found:\n  ',
+                  paste(strwrap(toString(unique(ctrl_assays$Assay)), width = 80), collapse = "\n")))
     }
   } else if (any(str_detect(df$Assay, regex("control|ctrl", ignore_case = TRUE)))) {
-    stop('Control assays have not been removed from the dataset.\n  Assays with "control" in their Assay field should be excluded.')
+    ctrl_assays <- df |>
+      dplyr::filter(str_detect(df$Assay, regex("control|ctrl", ignore_case = TRUE)))
+    
+    stop(paste0('Control assays have not been removed from the dataset.\n  Assays with "control" in their Assay field should be excluded.\n  The following control assays were found:\n  ',
+                paste(strwrap(toString(unique(ctrl_assays$Assay)), width = 80), collapse = "\n")))
   }
   
   withCallingHandlers({
@@ -455,14 +461,20 @@ olink_anova_posthoc <- function(df,
   }
 
   # Stop if control assays have not been removed
-  ctrl_types <- c("amp_ctrl", "ext_ctrl", "inc_ctrl")
-
   if ("AssayType" %in% names(df)) {
-    if (any(ctrl_types %in% df$AssayType)) {
-      stop('Control assays have not been removed from the dataset.\n  Assays with AssayType != "assay" should be excluded.')
+    if (any(df$AssayType != "assay")) {
+      ctrl_assays <- df |>
+        dplyr::filter(AssayType != "assay")
+      
+      stop(paste0('Control assays have not been removed from the dataset.\n  Assays with AssayType != "assay" should be excluded.\n  The following control assays were found:\n  ',
+                  paste(strwrap(toString(unique(ctrl_assays$Assay)), width = 80), collapse = "\n")))
     }
   } else if (any(str_detect(df$Assay, regex("control|ctrl", ignore_case = TRUE)))) {
-    stop('Control assays have not been removed from the dataset.\n  Assays with "control" in their Assay field should be excluded.')
+    ctrl_assays <- df |>
+      dplyr::filter(str_detect(df$Assay, regex("control|ctrl", ignore_case = TRUE)))
+    
+    stop(paste0('Control assays have not been removed from the dataset.\n  Assays with "control" in their Assay field should be excluded.\n  The following control assays were found:\n  ',
+                paste(strwrap(toString(unique(ctrl_assays$Assay)), width = 80), collapse = "\n")))
   }
   
   withCallingHandlers({

--- a/OlinkAnalyze/R/Olink_boxplot.R
+++ b/OlinkAnalyze/R/Olink_boxplot.R
@@ -26,12 +26,12 @@
 #' \donttest{
 #'
 #' library(dplyr)
-#'
-#' anova_results <- olink_anova(npx_data1, variable = "Site")
+#' npx_df <- npx_data1 %>% filter(!grepl('control|ctrl',SampleID, ignore.case = TRUE))
+#' anova_results <- olink_anova(npx_df, variable = "Site")
 #' significant_assays <- anova_results %>%
 #'     filter(Threshold == 'Significant') %>%
 #'     pull(OlinkID)
-#' olink_boxplot(npx_data1,
+#' olink_boxplot(npx_df,
 #'               variable = "Site",
 #'               olinkid_list = significant_assays,
 #'               verbose = TRUE,

--- a/OlinkAnalyze/man/olink_anova.Rd
+++ b/OlinkAnalyze/man/olink_anova.Rd
@@ -57,6 +57,8 @@ The function handles both factor and numerical variables and/or covariates. \cr\
 Samples that have no variable information or missing factor levels are automatically removed from the analysis (specified in a message if verbose = TRUE).
 Character columns in the input dataframe are automatically converted to factors (specified in a message if verbose = TRUE).
 Numerical variables are not converted to factors.
+Control samples (SampleType is not "SAMPLE, or SampleID contains "control" or "ctrl") should be removed before using this function.
+Control assays (AssayType is not "assay", or Assay contains "control" or "ctrl") should be removed before using this function.
 If a numerical variable is to be used as a factor, this conversion needs to be done on the dataframe before the function call. \cr\cr
 Crossed analysis, i.e. A*B formula notation, is inferred from the variable argument in the following cases: \cr
 \itemize{

--- a/OlinkAnalyze/man/olink_anova.Rd
+++ b/OlinkAnalyze/man/olink_anova.Rd
@@ -57,7 +57,7 @@ The function handles both factor and numerical variables and/or covariates. \cr\
 Samples that have no variable information or missing factor levels are automatically removed from the analysis (specified in a message if verbose = TRUE).
 Character columns in the input dataframe are automatically converted to factors (specified in a message if verbose = TRUE).
 Numerical variables are not converted to factors.
-Control samples (SampleType is not "SAMPLE, or SampleID contains "control" or "ctrl") should be removed before using this function.
+Control samples should be removed before using this function.
 Control assays (AssayType is not "assay", or Assay contains "control" or "ctrl") should be removed before using this function.
 If a numerical variable is to be used as a factor, this conversion needs to be done on the dataframe before the function call. \cr\cr
 Crossed analysis, i.e. A*B formula notation, is inferred from the variable argument in the following cases: \cr

--- a/OlinkAnalyze/man/olink_anova.Rd
+++ b/OlinkAnalyze/man/olink_anova.Rd
@@ -77,7 +77,7 @@ The threshold is determined by logic evaluation of Adjusted_pval < 0.05. Covaria
 
 library(dplyr)
 
-npx_df <- npx_data1 \%>\% filter(!grepl('control',SampleID, ignore.case = TRUE))
+npx_df <- npx_data1 \%>\% filter(!grepl('control|ctrl',SampleID, ignore.case = TRUE))
 
 #One-way ANOVA, no covariates.
 #Results in a model NPX~Time

--- a/OlinkAnalyze/man/olink_anova_posthoc.Rd
+++ b/OlinkAnalyze/man/olink_anova_posthoc.Rd
@@ -64,7 +64,7 @@ Columns include:
 Performs a post hoc ANOVA test using emmeans::emmeans with Tukey p-value adjustment per assay (by OlinkID) for each panel at confidence level 0.95.
 See \code{olink_anova} for details of input notation. \cr\cr
 The function handles both factor and numerical variables and/or covariates.
-Control samples (SampleType is not "SAMPLE, or SampleID contains "control" or "ctrl") should be removed before using this function.
+Control samples should be removed before using this function.
 Control assays (AssayType is not "assay", or Assay contains "control" or "ctrl") should be removed before using this function.
 The posthoc test for a numerical variable compares the difference in means of the outcome variable (default: NPX) for 1 standard deviation difference in the numerical variable, e.g.
 mean NPX at mean(numerical variable) versus mean NPX at mean(numerical variable) + 1*SD(numerical variable).

--- a/OlinkAnalyze/man/olink_anova_posthoc.Rd
+++ b/OlinkAnalyze/man/olink_anova_posthoc.Rd
@@ -74,7 +74,7 @@ mean NPX at mean(numerical variable) versus mean NPX at mean(numerical variable)
 
 library(dplyr)
 
-npx_df <- npx_data1 \%>\% filter(!grepl('control',SampleID, ignore.case = TRUE))
+npx_df <- npx_data1 \%>\% filter(!grepl('control|ctrl',SampleID, ignore.case = TRUE))
 
 #Two-way ANOVA, one main effect (Site) covariate.
 #Results in model NPX~Treatment*Time+Site.

--- a/OlinkAnalyze/man/olink_anova_posthoc.Rd
+++ b/OlinkAnalyze/man/olink_anova_posthoc.Rd
@@ -64,6 +64,8 @@ Columns include:
 Performs a post hoc ANOVA test using emmeans::emmeans with Tukey p-value adjustment per assay (by OlinkID) for each panel at confidence level 0.95.
 See \code{olink_anova} for details of input notation. \cr\cr
 The function handles both factor and numerical variables and/or covariates.
+Control samples (SampleType is not "SAMPLE, or SampleID contains "control" or "ctrl") should be removed before using this function.
+Control assays (AssayType is not "assay", or Assay contains "control" or "ctrl") should be removed before using this function.
 The posthoc test for a numerical variable compares the difference in means of the outcome variable (default: NPX) for 1 standard deviation difference in the numerical variable, e.g.
 mean NPX at mean(numerical variable) versus mean NPX at mean(numerical variable) + 1*SD(numerical variable).
 }

--- a/OlinkAnalyze/man/olink_boxplot.Rd
+++ b/OlinkAnalyze/man/olink_boxplot.Rd
@@ -43,12 +43,12 @@ Generates faceted boxplots of NPX vs. grouping variable(s) for a given list of p
 \donttest{
 
 library(dplyr)
-
-anova_results <- olink_anova(npx_data1, variable = "Site")
+npx_df <- npx_data1 \%>\% filter(!grepl('control|ctrl',SampleID, ignore.case = TRUE))
+anova_results <- olink_anova(npx_df, variable = "Site")
 significant_assays <- anova_results \%>\%
     filter(Threshold == 'Significant') \%>\%
     pull(OlinkID)
-olink_boxplot(npx_data1,
+olink_boxplot(npx_df,
               variable = "Site",
               olinkid_list = significant_assays,
               verbose = TRUE,

--- a/OlinkAnalyze/tests/testthat/test-Olink_anova.R
+++ b/OlinkAnalyze/tests/testthat/test-Olink_anova.R
@@ -133,11 +133,5 @@ test_that("olink_anova_posthoc function works", {
   expect_error(olink_anova_posthoc(npx_data_format221010_ext_ctrl, 
                                    variable = 'Site', 
                                    effect = 'Site')) # Assay controls not removed, no AssayType
-  expect_error(olink_anova_posthoc(npx_data_format221010_sample_controls, 
-                                   variable = 'Site', 
-                                   effect = 'Site')) # Sample controls not removed, SampleType present
-  expect_warning(olink_anova_posthoc(npx_data1_sample_controls, 
-                                   variable = 'Site', 
-                                   effect = 'Site')) # Sample controls not removed, no SampleType
   
 })

--- a/OlinkAnalyze/tests/testthat/test-Olink_anova.R
+++ b/OlinkAnalyze/tests/testthat/test-Olink_anova.R
@@ -33,24 +33,6 @@ npx_data_format221010_AssayType <- npx_data_format221010_ext_ctrl |>
 npx_data_format221010_no_ctrl <- npx_data_format221010 |>
   dplyr::filter(!str_detect(Assay, "control"))
 
-# Add sample controls for testing
-# Without SampleType column, we can use npx_data1
-npx_data1_sample_controls <- npx_data1
-
-# With SampleType column
-sample_type_col <- rbind(
-  matrix(nrow = 10, ncol = 1, data = "PLATE_CONTROL"),
-  matrix(nrow = 4, ncol = 1, data = "NEGATIVE_CONTROL"),
-  matrix(nrow = 6, ncol = 1, data = "SAMPLE_CONTROL"),
-  matrix(
-    nrow = nrow(npx_data_format221010_no_ctrl) - 20,
-    ncol = 1, data = "SAMPLE"
-  )
-)
-
-npx_data_format221010_sample_controls <- npx_data_format221010_no_ctrl |>
-  dplyr::mutate(SampleType = sample(sample_type_col))
-
 # Remove sample controls from npx_data1 to preserve test results
 npx_data1 <- npx_data1 |>
   dplyr::filter(!stringr::str_detect(npx_data1$SampleID, 

--- a/OlinkAnalyze/tests/testthat/test-Olink_anova.R
+++ b/OlinkAnalyze/tests/testthat/test-Olink_anova.R
@@ -111,7 +111,7 @@ test_that("olink_anova function works", {
   expect_error(olink_anova(npx_data_format221010_AssayType, variable = "Site")) # Assay controls not removed, AssayType present
   expect_error(olink_anova(npx_data_format221010_ext_ctrl, variable = "Site")) # Assay controls not removed, no AssayType
   expect_error(olink_anova(npx_data_format221010_sample_controls, variable = "Site")) # Sample controls not removed, SampleType present
-  expect_error(olink_anova(npx_data1_sample_controls, variable = "Site")) # Sample controls not removed, no AssayType
+  expect_warning(olink_anova(npx_data1_sample_controls, variable = "Site")) # Sample controls not removed, no SampleType
   
   })
 
@@ -139,7 +139,7 @@ test_that("olink_anova_posthoc function works", {
   expect_error(olink_anova_posthoc(npx_data_format221010_sample_controls, 
                                    variable = 'Site', 
                                    effect = 'Site')) # Sample controls not removed, SampleType present
-  expect_error(olink_anova_posthoc(npx_data1_sample_controls, 
+  expect_warning(olink_anova_posthoc(npx_data1_sample_controls, 
                                    variable = 'Site', 
                                    effect = 'Site')) # Sample controls not removed, no SampleType
   

--- a/OlinkAnalyze/tests/testthat/test-Olink_anova.R
+++ b/OlinkAnalyze/tests/testthat/test-Olink_anova.R
@@ -110,9 +110,6 @@ test_that("olink_anova function works", {
   
   expect_error(olink_anova(npx_data_format221010_AssayType, variable = "Site")) # Assay controls not removed, AssayType present
   expect_error(olink_anova(npx_data_format221010_ext_ctrl, variable = "Site")) # Assay controls not removed, no AssayType
-  expect_error(olink_anova(npx_data_format221010_sample_controls, variable = "Site")) # Sample controls not removed, SampleType present
-  expect_warning(olink_anova(npx_data1_sample_controls, variable = "Site")) # Sample controls not removed, no SampleType
-  
   })
 
 test_that("olink_anova_posthoc function works", {

--- a/OlinkAnalyze/vignettes/Vignett.Rmd
+++ b/OlinkAnalyze/vignettes/Vignett.Rmd
@@ -384,6 +384,8 @@ The olink_anova is a wrapper function that performs an ANOVA F-test for each ass
 
 Samples with missing variable information or factor levels are excluded from the analysis. Character columns in the input data frame are converted to factors. The automatic handling of the data from above is announced by a message if the flag *verbose=TRUE*.
 
+Control samples (SampleType is not "SAMPLE, or SampleID contains "control" or "ctrl") and control assays (AssayType is not "assay", or Assay contains "control" or "ctrl") should be removed before using this function.
+
 Crossed/interaction analysis, i.e. A*B formula notation, is inferred from the variable argument in the following cases: 
 
 * c('A','B')
@@ -406,14 +408,23 @@ Adjusted p-values are calculated using the function *p.adjust* from the R librar
 * verbose: Logical. Default: True. If information about removed samples, factor conversion and final model formula is to be printed to the console.
 
 ```{r message=FALSE, eval=FALSE}
+# Remove control samples and assays
+npx_data1_no_controls <- npx_data1 |>
+  filter(!str_detect(SampleID,
+                     regex("control|ctrl", 
+                           ignore_case = TRUE))) |>
+  filter(!str_detect(Assay, 
+                     regex("control|ctrl", 
+                           ignore_case = TRUE)))
+  
 # One-way ANOVA, no covariates
-anova_results_oneway <- olink_anova(df = npx_data1, 
+anova_results_oneway <- olink_anova(df = npx_data1_no_controls, 
                                     variable = 'Site')
 # Two-way ANOVA, no covariates
-anova_results_twoway <- olink_anova(df = npx_data1, 
+anova_results_twoway <- olink_anova(df = npx_data1_no_controls, 
                                     variable = c('Site', 'Time'))
 # One-way ANOVA, Treatment as covariates
-anova_results_oneway <- olink_anova(df = npx_data1, 
+anova_results_oneway <- olink_anova(df = npx_data1_no_controls, 
                                     variable = 'Site',
                                     covariates = 'Treatment')
 ```
@@ -441,6 +452,8 @@ olink_anova_posthoc performs a post-hoc ANOVA test using the function *emmeans* 
 
 The function handles both factor and numerical variables and/or covariates. The post-hoc test for a numerical variable compares the difference in means of the outcome variable (default: NPX) for 1 standard deviation (SD) difference in the numerical variable, e.g. mean NPX at mean (numerical variable) versus mean NPX at mean (numerical variable) + 1*SD (numerical variable).
 
+Control samples (SampleType is not "SAMPLE, or SampleID contains "control" or "ctrl") and control assays (AssayType is not "assay", or Assay contains "control" or "ctrl") should be removed before using this function.
+
 ### Function arguments
 
 * df: NPX data frame in long format should minimally contain protein name (Assay), OlinkID, UniProt, Panel and an outcome factor with at least 3 levels.
@@ -454,13 +467,13 @@ The function handles both factor and numerical variables and/or covariates. The 
 
 ```{r message=FALSE, eval=FALSE}
 # calculate the p-value for the ANOVA
-anova_results_oneway <- olink_anova(df = npx_data1, 
+anova_results_oneway <- olink_anova(df = npx_data1_no_controls, 
                                     variable = 'Site')
 # extracting the significant proteins
 anova_results_oneway_significant <- anova_results_oneway %>%
   filter(Threshold == 'Significant') %>%
   pull(OlinkID)
-anova_posthoc_oneway_results <- olink_anova_posthoc(df = npx_data1,
+anova_posthoc_oneway_results <- olink_anova_posthoc(df = npx_data1_no_controls,
                                                     olinkid_list = anova_results_oneway_significant,
                                                     variable = 'Site',
                                                     effect = 'Site')
@@ -948,6 +961,9 @@ A list of objects of class *ggplot* (silently returned). Plots are also printed 
 
 The olink_boxplot function is used to generate boxplots of NPX values stratified on a variable for a given list of proteins. olink_boxplot uses the functions *ggplot* and *geom_boxplot* of the R library *ggplot2*.
 
+
+In order to annotate the plot with ANOVA posthoc analysis results, control samples (SampleType is not "SAMPLE, or SampleID contains "control" or "ctrl") and control assays (AssayType is not "assay", or Assay contains "control" or "ctrl") should be removed.
+
 ### Function arguments
 
 * df: NPX data frame in long format should minimally contain protein name (Assay), OlinkID, UniProt and a grouping variable.
@@ -959,19 +975,28 @@ The olink_boxplot function is used to generate boxplots of NPX values stratified
 * number_of_proteins_per_plot: Number of boxplots to include in the facets plot. Default 6.
 
 ```{r message=FALSE}
-plot <- npx_data1 %>%
+# Remove control samples and assays
+npx_data1_no_controls <- npx_data1 |>
+  filter(!str_detect(SampleID,
+                     regex("control|ctrl", 
+                           ignore_case = TRUE))) |>
+  filter(!str_detect(Assay, 
+                     regex("control|ctrl", 
+                           ignore_case = TRUE)))
+
+plot <- npx_data1_no_controls %>%
   na.omit() %>% # removing missing values which exists for Site
   olink_boxplot(variable = "Site", 
                 olinkid_list = c("OID00488", "OID01276"),
                 number_of_proteins_per_plot  = 2)
 plot[[1]]
 
-anova_posthoc_results<-npx_data1 %>% 
+anova_posthoc_results<-npx_data1_no_controls %>% 
   olink_anova_posthoc(olinkid_list = c("OID00488", "OID01276"),
                       variable = 'Site',
                       effect = 'Site')
 
-plot2 <- npx_data1 %>%
+plot2 <- npx_data1_no_controls %>%
   na.omit() %>% # removing missing values which exists for Site
   olink_boxplot(variable = "Site", 
                 olinkid_list = c("OID00488", "OID01276"),

--- a/OlinkAnalyze/vignettes/Vignett.Rmd
+++ b/OlinkAnalyze/vignettes/Vignett.Rmd
@@ -452,7 +452,7 @@ olink_anova_posthoc performs a post-hoc ANOVA test using the function *emmeans* 
 
 The function handles both factor and numerical variables and/or covariates. The post-hoc test for a numerical variable compares the difference in means of the outcome variable (default: NPX) for 1 standard deviation (SD) difference in the numerical variable, e.g. mean NPX at mean (numerical variable) versus mean NPX at mean (numerical variable) + 1*SD (numerical variable).
 
-Control samples (SampleType is not "SAMPLE, or SampleID contains "control" or "ctrl") and control assays (AssayType is not "assay", or Assay contains "control" or "ctrl") should be removed before using this function.
+Control samples and control assays (AssayType is not "assay", or Assay contains "control" or "ctrl") should be removed before using this function.
 
 ### Function arguments
 

--- a/OlinkAnalyze/vignettes/Vignett.Rmd
+++ b/OlinkAnalyze/vignettes/Vignett.Rmd
@@ -962,7 +962,7 @@ A list of objects of class *ggplot* (silently returned). Plots are also printed 
 The olink_boxplot function is used to generate boxplots of NPX values stratified on a variable for a given list of proteins. olink_boxplot uses the functions *ggplot* and *geom_boxplot* of the R library *ggplot2*.
 
 
-In order to annotate the plot with ANOVA posthoc analysis results, control samples (SampleType is not "SAMPLE, or SampleID contains "control" or "ctrl") and control assays (AssayType is not "assay", or Assay contains "control" or "ctrl") should be removed.
+In order to annotate the plot with ANOVA posthoc analysis results, control samples and control assays (AssayType is not "assay", or Assay contains "control" or "ctrl") should be removed.
 
 ### Function arguments
 

--- a/OlinkAnalyze/vignettes/Vignett.Rmd
+++ b/OlinkAnalyze/vignettes/Vignett.Rmd
@@ -384,7 +384,7 @@ The olink_anova is a wrapper function that performs an ANOVA F-test for each ass
 
 Samples with missing variable information or factor levels are excluded from the analysis. Character columns in the input data frame are converted to factors. The automatic handling of the data from above is announced by a message if the flag *verbose=TRUE*.
 
-Control samples (SampleType is not "SAMPLE, or SampleID contains "control" or "ctrl") and control assays (AssayType is not "assay", or Assay contains "control" or "ctrl") should be removed before using this function.
+Control samples and control assays (AssayType is not "assay", or Assay contains "control" or "ctrl") should be removed before using this function.
 
 Crossed/interaction analysis, i.e. A*B formula notation, is inferred from the variable argument in the following cases: 
 


### PR DESCRIPTION
# Title: Add an error ANOVA functions when control assays are present
**Problem:** ANOVA function crashes when sum of squares equals 0. Need to have a trycatch to remind customers to exclude internal control assays and external controls from statistical analyses.

**Solution:** Added a conditional statement in olink_anova() and olink_anova_posthoc() that throws an informative error if control assays have not been removed. Added unit tests.

## Checklist
- [x] Make sure you are requesting to **pull a feature/bugfix branch** (right side). This should not be main or develop.
- [x] Make sure you are make a pull request against either **main or develop** (left side). (Requesting to main should be reserved for bugfixes and new releases)
- [x] Add or update unit tests (if applicable)
- [x] Check your code with any unit tests (Run devtools::check() locally)
- [ ] Add neccessary documentation (if applicable)

## Type of changes

What type of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue) (https://olink.atlassian.net/browse/OA-2272)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Documentation Update 
- [ ] Other (explain)
