### PR TITLE
remove large test files from build

### DIFF
--- a/OlinkAnalyze/.Rbuildignore
+++ b/OlinkAnalyze/.Rbuildignore
@@ -14,3 +14,5 @@
 ^inst/WORDLIST
 ^CITATION\.cff$
 ^data-raw$
+^.RData
+^tests/data/.*[.]rds

--- a/OlinkAnalyze/DESCRIPTION
+++ b/OlinkAnalyze/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: OlinkAnalyze
 Title: Facilitate Analysis of Proteomic Data from Olink
-Version: 4.0.0
+Version: 4.0.1
 Authors@R: c(
     person("Kathleen", "Nevola", , "biostattools@olink.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-5183-6444", "kathy-nevola")),

--- a/OlinkAnalyze/NEWS.md
+++ b/OlinkAnalyze/NEWS.md
@@ -1,3 +1,7 @@
+# Olink Analyze 4.0.1
+## Minor Changes
+* larger rds files used for unit tests have been excluded from build to abide by CRAN size limitations (#462, @kathy-nevola)
+
 # Olink Analyze 4.0.0
 ## Major Changes
 * olink_normalization can now be used for bridging Explore 3072 data to Explore HT data (#453, #452, #439, #449, #447,#446, #441, #440, #434, #422, #436, #435 @klevdiamanti, @kathy-nevola, @kristynchin-olink, @dtopouza, @amrita-kar, @MasoumehSheikh)

--- a/OlinkAnalyze/cran-comments.md
+++ b/OlinkAnalyze/cran-comments.md
@@ -1,6 +1,6 @@
 ## Release Summary
 
-This release provides additional functionality and documentation to Olink Analyze 3.9. It also optimizes and improves reproducibility for olink_normalization() and educational materials for the new functionality.
+This release removes large files used for unit testing to meet CRAN size specifications.
 
 ## R CMD check results
 

--- a/OlinkAnalyze/tests/testthat/test-olink_normalization.R
+++ b/OlinkAnalyze/tests/testthat/test-olink_normalization.R
@@ -1,6 +1,5 @@
 # Test olink_normalization ----
 
-
 # this tests also all functions called norm_internal_* except from
 # "norm_internal_rename_cols". Namely:
 # - norm_internal_assay_median
@@ -12,24 +11,21 @@
 # - norm_internal_adjust_not_ref
 #
 
-# load normalized datasets generated with the original olink_normalization
-# function from OlinkAnalyze 3.8.2
-skip_if_not(file.exists("../data/example_3k_data.rds"))
-skip_if_not(file.exists("../data/example_HT_data.rds"))
-skip_if_not(file.exists("../data/ref_results_norm.rds"))
-get_ref_norm_res <- function() {
-  ref_norm_res_file <- test_path("..", "data", "ref_results_norm.rds")
-  readRDS(file = ref_norm_res_file)
-}
-ref_norm_res <- get_ref_norm_res()
-
 test_that(
   "olink_normalization - works - bridge normalization",
   {
-    ### bridge normalization - no norm column ----
-    skip_if_not(file.exists("../data/example_3k_data.rds"))
-    skip_if_not(file.exists("../data/example_HT_data.rds"))
     skip_if_not(file.exists("../data/ref_results_norm.rds"))
+
+    # load normalized datasets generated with the original olink_normalization
+    # function from OlinkAnalyze 3.8.2
+    get_ref_norm_res <- function() {
+      ref_norm_res_file <- test_path("..", "data", "ref_results_norm.rds")
+      readRDS(file = ref_norm_res_file)
+    }
+    ref_norm_res <- get_ref_norm_res()
+
+    ### bridge normalization - no norm column ----
+
     expect_warning(
       object = expect_message(
         object = bridge_no_norm <- olink_normalization(
@@ -132,10 +128,18 @@ test_that(
 test_that(
   "olink_normalization - works - intensity normalization",
   {
-    ### intensity normalization - no norm column ----
-    skip_if_not(file.exists("../data/example_3k_data.rds"))
-    skip_if_not(file.exists("../data/example_HT_data.rds"))
     skip_if_not(file.exists("../data/ref_results_norm.rds"))
+
+    # load normalized datasets generated with the original olink_normalization
+    # function from OlinkAnalyze 3.8.2
+    get_ref_norm_res <- function() {
+      ref_norm_res_file <- test_path("..", "data", "ref_results_norm.rds")
+      readRDS(file = ref_norm_res_file)
+    }
+    ref_norm_res <- get_ref_norm_res()
+
+    ### intensity normalization - no norm column ----
+
     expect_warning(
       object = expect_message(
         object = intensity_no_norm <- olink_normalization(
@@ -242,10 +246,18 @@ test_that(
 test_that(
   "olink_normalization - works - subset normalization",
   {
-    ### subset normalization - no norm column ----
-    skip_if_not(file.exists("../data/example_3k_data.rds"))
-    skip_if_not(file.exists("../data/example_HT_data.rds"))
     skip_if_not(file.exists("../data/ref_results_norm.rds"))
+
+    # load normalized datasets generated with the original olink_normalization
+    # function from OlinkAnalyze 3.8.2
+    get_ref_norm_res <- function() {
+      ref_norm_res_file <- test_path("..", "data", "ref_results_norm.rds")
+      readRDS(file = ref_norm_res_file)
+    }
+    ref_norm_res <- get_ref_norm_res()
+
+    ### subset normalization - no norm column ----
+
     expect_warning(
       object = expect_message(
         object = subset_no_norm <- olink_normalization(
@@ -352,10 +364,18 @@ test_that(
 test_that(
   "olink_normalization - works - reference median normalization",
   {
-    ### reference median normalization - no norm column ----
-    skip_if_not(file.exists("../data/example_3k_data.rds"))
-    skip_if_not(file.exists("../data/example_HT_data.rds"))
     skip_if_not(file.exists("../data/ref_results_norm.rds"))
+
+    # load normalized datasets generated with the original olink_normalization
+    # function from OlinkAnalyze 3.8.2
+    get_ref_norm_res <- function() {
+      ref_norm_res_file <- test_path("..", "data", "ref_results_norm.rds")
+      readRDS(file = ref_norm_res_file)
+    }
+    ref_norm_res <- get_ref_norm_res()
+
+    ### reference median normalization - no norm column ----
+
     expect_warning(
       object = expect_message(
         object = ref_med_no_norm <- olink_normalization(
@@ -452,10 +472,11 @@ test_that(
   {
     skip_if_not(file.exists("../data/example_3k_data.rds"))
     skip_if_not(file.exists("../data/example_HT_data.rds"))
-    skip_if_not(file.exists("../data/ref_results_norm.rds"))
-    # load example data
+
     data_3k <- get_example_data(filename = "example_3k_data.rds")
     data_ht <- get_example_data(filename = "example_HT_data.rds")
+
+    # load example data
 
     expect_message(
       object = ht_3k_norm <- olink_normalization(

--- a/OlinkAnalyze/tests/testthat/test-olink_normalization.R
+++ b/OlinkAnalyze/tests/testthat/test-olink_normalization.R
@@ -14,6 +14,9 @@
 
 # load normalized datasets generated with the original olink_normalization
 # function from OlinkAnalyze 3.8.2
+skip_if_not(file.exists("../data/example_3k_data.rds"))
+skip_if_not(file.exists("../data/example_HT_data.rds"))
+skip_if_not(file.exists("../data/ref_results_norm.rds"))
 get_ref_norm_res <- function() {
   ref_norm_res_file <- test_path("..", "data", "ref_results_norm.rds")
   readRDS(file = ref_norm_res_file)
@@ -24,7 +27,9 @@ test_that(
   "olink_normalization - works - bridge normalization",
   {
     ### bridge normalization - no norm column ----
-
+    skip_if_not(file.exists("../data/example_3k_data.rds"))
+    skip_if_not(file.exists("../data/example_HT_data.rds"))
+    skip_if_not(file.exists("../data/ref_results_norm.rds"))
     expect_warning(
       object = expect_message(
         object = bridge_no_norm <- olink_normalization(
@@ -128,7 +133,9 @@ test_that(
   "olink_normalization - works - intensity normalization",
   {
     ### intensity normalization - no norm column ----
-
+    skip_if_not(file.exists("../data/example_3k_data.rds"))
+    skip_if_not(file.exists("../data/example_HT_data.rds"))
+    skip_if_not(file.exists("../data/ref_results_norm.rds"))
     expect_warning(
       object = expect_message(
         object = intensity_no_norm <- olink_normalization(
@@ -236,7 +243,9 @@ test_that(
   "olink_normalization - works - subset normalization",
   {
     ### subset normalization - no norm column ----
-
+    skip_if_not(file.exists("../data/example_3k_data.rds"))
+    skip_if_not(file.exists("../data/example_HT_data.rds"))
+    skip_if_not(file.exists("../data/ref_results_norm.rds"))
     expect_warning(
       object = expect_message(
         object = subset_no_norm <- olink_normalization(
@@ -344,7 +353,9 @@ test_that(
   "olink_normalization - works - reference median normalization",
   {
     ### reference median normalization - no norm column ----
-
+    skip_if_not(file.exists("../data/example_3k_data.rds"))
+    skip_if_not(file.exists("../data/example_HT_data.rds"))
+    skip_if_not(file.exists("../data/ref_results_norm.rds"))
     expect_warning(
       object = expect_message(
         object = ref_med_no_norm <- olink_normalization(
@@ -439,6 +450,9 @@ test_that(
 test_that(
   "olink_normalization - works - 3k-HT normalization",
   {
+    skip_if_not(file.exists("../data/example_3k_data.rds"))
+    skip_if_not(file.exists("../data/example_HT_data.rds"))
+    skip_if_not(file.exists("../data/ref_results_norm.rds"))
     # load example data
     data_3k <- get_example_data(filename = "example_3k_data.rds")
     data_ht <- get_example_data(filename = "example_HT_data.rds")

--- a/OlinkAnalyze/tests/testthat/test-olink_normalization_product.R
+++ b/OlinkAnalyze/tests/testthat/test-olink_normalization_product.R
@@ -190,6 +190,7 @@ test_that(
   {
     skip_if_not(file.exists("../data/example_3k_data.rds"))
     skip_if_not(file.exists("../data/example_HT_data.rds"))
+
     data_3k <- get_example_data(filename = "example_3k_data.rds")
     data_ht <- get_example_data(filename = "example_HT_data.rds")
 

--- a/OlinkAnalyze/tests/testthat/test-olink_normalization_product.R
+++ b/OlinkAnalyze/tests/testthat/test-olink_normalization_product.R
@@ -3,6 +3,7 @@
 test_that(
   "olink_normalization_is_bridgeable - works",
   {
+    skip_if_not(file.exists(normalizePath("../data/example_3k_data.rds")))
     data_3k <- get_example_data(filename = "example_3k_data.rds")
     data_ht <- get_example_data(filename = "example_HT_data.rds")
 
@@ -93,6 +94,9 @@ test_that(
 test_that(
   "olink_normalization_qs - works - compare to reference",
   {
+    skip_if_not(file.exists("../data/example_3k_data.rds"))
+    skip_if_not(file.exists("../data/example_HT_data.rds"))
+
     data_3k <- get_example_data(filename = "example_3k_data.rds")
     data_ht <- get_example_data(filename = "example_HT_data.rds")
 
@@ -184,6 +188,8 @@ test_that(
 test_that(
   "olink_normalization_qs - works - expected output, all bridge samples",
   {
+    skip_if_not(file.exists("../data/example_3k_data.rds"))
+    skip_if_not(file.exists("../data/example_HT_data.rds"))
     data_3k <- get_example_data(filename = "example_3k_data.rds")
     data_ht <- get_example_data(filename = "example_HT_data.rds")
 
@@ -302,6 +308,9 @@ test_that(
 test_that(
   "olink_normalization_qs - works - expected output, 50 bridge samples",
   {
+    skip_if_not(file.exists("../data/example_3k_data.rds"))
+    skip_if_not(file.exists("../data/example_HT_data.rds"))
+
     data_3k <- get_example_data(filename = "example_3k_data.rds")
     data_ht <- get_example_data(filename = "example_HT_data.rds")
 

--- a/OlinkAnalyze/tests/testthat/test-olink_normalization_utils.R
+++ b/OlinkAnalyze/tests/testthat/test-olink_normalization_utils.R
@@ -143,7 +143,8 @@ test_that(
   "olink_norm_input_check - works - cross-platform normalization",
   {
     skip_if_not_installed("arrow")
-    skip()
+    skip_if_not(file.exists("../data/example_3k_data.rds"))
+    skip_if_not(file.exists("../data/example_HT_data.rds"))
 
     data_3k <- get_example_data(filename = "example_3k_data.rds")
     data_ht <- get_example_data(filename = "example_HT_data.rds")
@@ -2412,6 +2413,7 @@ test_that(
     skip_if_not_installed("arrow")
     skip_if_not(file.exists("../data/example_3k_data.rds"))
     skip_if_not(file.exists("../data/example_HT_data.rds"))
+
     data_3k <- get_example_data(filename = "example_3k_data.rds")
     data_ht <- get_example_data(filename = "example_HT_data.rds")
 
@@ -2541,6 +2543,7 @@ test_that(
     skip_if_not_installed("arrow")
     skip_if_not(file.exists("../data/example_3k_data.rds"))
     skip_if_not(file.exists("../data/example_HT_data.rds"))
+
     data_3k <- get_example_data(filename = "example_3k_data.rds")
     data_ht <- get_example_data(filename = "example_HT_data.rds")
 
@@ -2586,6 +2589,7 @@ test_that(
     skip_if_not_installed("arrow")
     skip_if_not(file.exists("../data/example_3k_data.rds"))
     skip_if_not(file.exists("../data/example_HT_data.rds"))
+
     data_3k <- get_example_data(filename = "example_3k_data.rds")
     data_ht <- get_example_data(filename = "example_HT_data.rds")
 
@@ -2701,6 +2705,7 @@ test_that(
     )
 
     # cross-platform norm - reference samples in datasets ----
+
     skip_if_not(file.exists("../data/example_3k_data.rds"))
     skip_if_not(file.exists("../data/example_HT_data.rds"))
 
@@ -3746,11 +3751,13 @@ test_that(
   "olink_norm_input_clean_assays - works - invalid OID in df*",
   {
     skip_if_not_installed("arrow")
-    skip()
+    skip_if_not(file.exists("../data/example_3k_data.rds"))
+    skip_if_not(file.exists("../data/example_HT_data.rds"))
 
-    ## all assays start with OID12345_OID12345 in 1 df ----
     data_3k <- get_example_data(filename = "example_3k_data.rds")
     data_ht <- get_example_data(filename = "example_HT_data.rds")
+
+    ## all assays start with OID12345_OID12345 in 1 df ----
 
     lst_df_v0 <- list(
       "p1" = data_3k |>

--- a/OlinkAnalyze/tests/testthat/test-olink_normalization_utils.R
+++ b/OlinkAnalyze/tests/testthat/test-olink_normalization_utils.R
@@ -143,6 +143,7 @@ test_that(
   "olink_norm_input_check - works - cross-platform normalization",
   {
     skip_if_not_installed("arrow")
+    skip()
 
     data_3k <- get_example_data(filename = "example_3k_data.rds")
     data_ht <- get_example_data(filename = "example_HT_data.rds")
@@ -2409,7 +2410,8 @@ test_that(
   "olink_norm_input_cross_product - works - bridge normalization",
   {
     skip_if_not_installed("arrow")
-
+    skip_if_not(file.exists("../data/example_3k_data.rds"))
+    skip_if_not(file.exists("../data/example_HT_data.rds"))
     data_3k <- get_example_data(filename = "example_3k_data.rds")
     data_ht <- get_example_data(filename = "example_HT_data.rds")
 
@@ -2473,6 +2475,8 @@ test_that(
   "olink_norm_input_cross_product - works - cross-product normalization",
   {
     skip_if_not_installed("arrow")
+    skip_if_not(file.exists("../data/example_3k_data.rds"))
+    skip_if_not(file.exists("../data/example_HT_data.rds"))
 
     data_3k <- get_example_data(filename = "example_3k_data.rds")
     data_ht <- get_example_data(filename = "example_HT_data.rds")
@@ -2535,7 +2539,8 @@ test_that(
   "olink_norm_input_cross_product - error - unexpected normalization",
   {
     skip_if_not_installed("arrow")
-
+    skip_if_not(file.exists("../data/example_3k_data.rds"))
+    skip_if_not(file.exists("../data/example_HT_data.rds"))
     data_3k <- get_example_data(filename = "example_3k_data.rds")
     data_ht <- get_example_data(filename = "example_HT_data.rds")
 
@@ -2579,7 +2584,8 @@ test_that(
   "olink_norm_input_cross_product - error - incorrect reference project",
   {
     skip_if_not_installed("arrow")
-
+    skip_if_not(file.exists("../data/example_3k_data.rds"))
+    skip_if_not(file.exists("../data/example_HT_data.rds"))
     data_3k <- get_example_data(filename = "example_3k_data.rds")
     data_ht <- get_example_data(filename = "example_HT_data.rds")
 
@@ -2695,6 +2701,8 @@ test_that(
     )
 
     # cross-platform norm - reference samples in datasets ----
+    skip_if_not(file.exists("../data/example_3k_data.rds"))
+    skip_if_not(file.exists("../data/example_HT_data.rds"))
 
     data_3k <- get_example_data(filename = "example_3k_data.rds")
     data_ht <- get_example_data(filename = "example_HT_data.rds")
@@ -3738,9 +3746,9 @@ test_that(
   "olink_norm_input_clean_assays - works - invalid OID in df*",
   {
     skip_if_not_installed("arrow")
+    skip()
 
     ## all assays start with OID12345_OID12345 in 1 df ----
-
     data_3k <- get_example_data(filename = "example_3k_data.rds")
     data_ht <- get_example_data(filename = "example_HT_data.rds")
 


### PR DESCRIPTION
CRAN reports tarball at 7 mb, due to test data being included in submission. As a short term fix, I have skipped tests if the file doesnt exist and added it to .Rbuildignore. Tests passing locally and tarball locally compiles at 4 MB (under 5 MB CRAN limit).

More permanent solution will need to be further investigated for future release.