### PR TITLE
Block should be read as a character not integer

### DIFF
--- a/OlinkAnalyze/R/read_npx_csv.R
+++ b/OlinkAnalyze/R/read_npx_csv.R
@@ -66,5 +66,10 @@ read_npx_csv <- function(filename) {
     }
   }
 
+  if ("Block" %in% colnames(df_npx)) {
+    df_npx <- df_npx %>%
+      dplyr::mutate(Block = as.character(Block))
+  }
+
   return(df_npx)
 }


### PR DESCRIPTION
**Problem:** Currently if Block is 1,2,3... and file is a csv, the input will be int. For parquet and in  specification, Block should be char.

**Solution:** When Block exists, set to character in read_NPX_csv.R

**Key Features:**

* Key feature 1
* Key feature 2
* ...

## Checklist
- [ ] Make sure you are requesting to **pull a feature/bugfix branch** (right side). This should not be main or develop.
- [ ] Make sure you are make a pull request against either **main or develop** (left side). (Requesting to main should be reserved for bugfixes and new releases)
- [ ] Add or update unit tests (if applicable)
- [ ] Check your code with any unit tests (Run devtools::check() locally)
- [ ] Add neccessary documentation (if applicable)

## Type of changes

What type of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue) (link the issue on the right)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Documentation Update 
- [ ] Other (explain)

## Further comments
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, any questions you have, etc...

Consider linking any issues (#issue-number ) or adding @mentions to ensure specific people see it.
