### PR TITLE
Oa 2168 Documenting within study randomization

### DIFF
--- a/OlinkAnalyze/R/Olink_plate_randomizer.R
+++ b/OlinkAnalyze/R/Olink_plate_randomizer.R
@@ -210,7 +210,7 @@ generatePlateHolder <- function(n.plates,n.spots,n.samples, PlateSize, num_ctrl,
 
 #' Randomly assign samples to plates
 #'
-#' Generates a scheme for how to plate samples with an option to keep subjects on the same plate.
+#' Generates a scheme for how to plate samples with an option to keep subjects on the same plate and/or to keep studies together.
 #'
 #' Variables of interest should if possible be randomized across plates to avoid confounding with potential plate effects. In the case of multiple samples per subject (e.g. in longitudinal studies), Olink recommends keeping each subject on the same plate. This can be achieved using the SubjectColumn argument.
 #' @param Manifest tibble/data frame in long format containing all sample ID's. Sample ID column must be named SampleID.
@@ -222,6 +222,7 @@ generatePlateHolder <- function(n.plates,n.spots,n.samples, PlateSize, num_ctrl,
 #' @param num_ctrl Numeric. Number of controls on each plate (default = 8)
 #' @param rand_ctrl Logical. Whether controls are added to be randomized across the plate (default = FALSE)
 #' @param seed Seed to set. Highly recommend setting this for reproducibility.
+#' @param study String. Optional. Name of column that includes study information. For when multiple studies are being plated and randomizing within studies. If `study` column is present in manifest, within study randomization will be performed.
 #' @return A "tibble" including SampleID, SubjectID etc. assigned to well positions.
 #' Columns include same columns as Manifest with additional columns:
 #' \itemize{
@@ -263,7 +264,7 @@ generatePlateHolder <- function(n.plates,n.spots,n.samples, PlateSize, num_ctrl,
 #' @importFrom tibble is_tibble
 
 #Main randomization function
-olink_plate_randomizer <- function(Manifest, PlateSize = 96, Product, SubjectColumn, iterations=500, available.spots, num_ctrl = 8, rand_ctrl = FALSE, seed){
+olink_plate_randomizer <- function(Manifest, PlateSize = 96, Product, SubjectColumn, iterations=500, available.spots, num_ctrl = 8, rand_ctrl = FALSE, seed, study = NULL){
   if(num_ctrl < 1 | num_ctrl != as.integer(num_ctrl)){
     stop("`num_ctrl` must be a positive integer.")
   }
@@ -275,6 +276,11 @@ olink_plate_randomizer <- function(Manifest, PlateSize = 96, Product, SubjectCol
 
   if(!missing(Product)){
     PlateSize <- product_to_platesize(Product)
+  }
+
+  if(is.null(study)&("study" %in% names(Manifest))){
+    study <- "study"
+    cli::cli_inform("`study` column detected in manifest. Randomizing within study.")
   }
 
   # Check if there are any duplicated Sample IDs in manifest
@@ -341,7 +347,7 @@ olink_plate_randomizer <- function(Manifest, PlateSize = 96, Product, SubjectCol
   }
 
   #### Complete randomization if subjectID not given ####
-  if(missing(SubjectColumn) & suppressWarnings(is.null(Manifest$study))){
+  if(missing(SubjectColumn) & is.null(study)){
     # randomly order the first X rows (x being number of samples) from plate layout to assign samples to
     all.plates <- all.plates[sample(1:(nrow(Manifest)+num_ctrl*rand_ctrl*PlatesNeeded)),]
 
@@ -384,7 +390,7 @@ olink_plate_randomizer <- function(Manifest, PlateSize = 96, Product, SubjectCol
 
 
   #### Keep subjects together ####
-  if(!missing(SubjectColumn) & suppressWarnings(is.null(Manifest$study))){
+  if(!missing(SubjectColumn) & is.null(study)){
     message("Assigning subjects to plates\n")
     for(i in 1:iterations){
       # prints ... for interations
@@ -465,8 +471,8 @@ olink_plate_randomizer <- function(Manifest, PlateSize = 96, Product, SubjectCol
   }
 
   #### Keep subjects together and keep studies together ####
-  if(!missing(SubjectColumn) & suppressWarnings(!is.null(Manifest$study))){
-    message("Assigning subjects to plates. 'study' column detected so keeping studies together during randomization. \n")
+  if(!missing(SubjectColumn) & !is.null(study)){
+    message("Assigning subjects to plates. Keeping studies together during randomization. \n")
     # When randomizing controls
     all.plates$SampleID <- NA_character_
     ctrl_locations <- all.plates |>
@@ -604,7 +610,7 @@ olink_plate_randomizer <- function(Manifest, PlateSize = 96, Product, SubjectCol
   }
 
   #### Complete randomization within studies when subjectID is not given ####
-  if(missing(SubjectColumn) & suppressWarnings(!is.null(Manifest$study))){
+  if(missing(SubjectColumn) & !is.null(study)){
     message("Assigning subjects to plates. 'study' column detected so keeping studies together during randomization. \n")
 
     out.manifest <- matrix(nrow = 0,ncol = ncol(Manifest))

--- a/OlinkAnalyze/man/olink_plate_randomizer.Rd
+++ b/OlinkAnalyze/man/olink_plate_randomizer.Rd
@@ -13,7 +13,8 @@ olink_plate_randomizer(
   available.spots,
   num_ctrl = 8,
   rand_ctrl = FALSE,
-  seed
+  seed,
+  study = NULL
 )
 }
 \arguments{
@@ -34,6 +35,8 @@ olink_plate_randomizer(
 \item{rand_ctrl}{Logical. Whether controls are added to be randomized across the plate (default = FALSE)}
 
 \item{seed}{Seed to set. Highly recommend setting this for reproducibility.}
+
+\item{study}{String. Optional. Name of column that includes study information. For when multiple studies are being plated and randomizing within studies. If \code{study} column is present in manifest, within study randomization will be performed.}
 }
 \value{
 A "tibble" including SampleID, SubjectID etc. assigned to well positions.
@@ -46,7 +49,7 @@ Columns include same columns as Manifest with additional columns:
 }
 }
 \description{
-Generates a scheme for how to plate samples with an option to keep subjects on the same plate.
+Generates a scheme for how to plate samples with an option to keep subjects on the same plate and/or to keep studies together.
 }
 \details{
 Variables of interest should if possible be randomized across plates to avoid confounding with potential plate effects. In the case of multiple samples per subject (e.g. in longitudinal studies), Olink recommends keeping each subject on the same plate. This can be achieved using the SubjectColumn argument.

--- a/OlinkAnalyze/man/olink_plate_randomizer.Rd
+++ b/OlinkAnalyze/man/olink_plate_randomizer.Rd
@@ -63,11 +63,15 @@ randomized.manifest_a <- olink_plate_randomizer(manifest, seed=12345)
 randomized.manifest_b <- olink_plate_randomizer(manifest,SubjectColumn="SubjectID",
                                                         available.spots=c(88,88), seed=12345)
 
+# Generate randomization scheme that keeps samples from the same study together
+randomized.manifest_c <- olink_plate_randomizer(manifest, study = "Site")
+
 #Visualize the generated plate layouts
 olink_displayPlateLayout(randomized.manifest_a, fill.color = 'Site')
 olink_displayPlateLayout(randomized.manifest_a, fill.color = 'SubjectID')
 olink_displayPlateLayout(randomized.manifest_b, fill.color = 'Site')
 olink_displayPlateLayout(randomized.manifest_b, fill.color = 'SubjectID')
+olink_displayPlateLayout(randomized.manifest_c, fill.color = 'Site')
 
 #Validate that sites are properly randomized
 olink_displayPlateDistributions(randomized.manifest_a, fill.color = 'Site')

--- a/OlinkAnalyze/vignettes/plate_randomizer.Rmd
+++ b/OlinkAnalyze/vignettes/plate_randomizer.Rmd
@@ -16,6 +16,12 @@ vignette: >
 library(OlinkAnalyze)
 ```
 
+```{r include=FALSE}
+library(OlinkAnalyze)
+data(manifest)
+```
+
+
 ```{r, echo=FALSE,message=FALSE}
 library(dplyr)
 library(ggplot2)

--- a/OlinkAnalyze/vignettes/plate_randomizer.Rmd
+++ b/OlinkAnalyze/vignettes/plate_randomizer.Rmd
@@ -33,12 +33,6 @@ knitr::opts_chunk$set(warning = FALSE,
 This vignette describes how to use Olink® Analyze to randomize the samples with an option to keep subjects on the same plate. When a study is well randomized the experimental variables can be considered to be evenly distributed across each plate, even for a larger study. What variables to randomize for should be decided for each study as these vary with the study purpose. Correct sample randomization will empower your study and minimize the risk of introducing any bias that can confound downstream analyses. If at all possible, samples from the same subject that are taken at various times during a longitudinal research should all be placed on the same plate to further limit data fluctuation. In order to evenly disperse the remaining experimental variables between plates, the individuals should subsequently be distributed. If randomization is not performed true biological variation may be missed or misidentified as e.g. technical variations. However, it would be challenging for us to control every variable. Most of the time, a complete randomization will be carried out, and the outcomes can be assessed by visualizing the layout of the plates. In this vignette, you will learn how to achieve this using the `olink_plate_randomizer()` function. And on top of that, you will also learn how to use `olink_displayPlateLayout()` and `olink_displayPlateDistributions()` to evaluate the performed randomization based on a given grouping variable.
 
 
-```{r Outlier_data, include=FALSE}
-library(OlinkAnalyze)
-data(manifest)
-```
-
-
 ## Sample randomization
 
 The input manifest should be a tibble/data frame in long format containing all sample ID's. Sample ID column must be named SampleID. An example manifest is shown in Table 1. 
@@ -115,7 +109,13 @@ randomized_manifest %>%
 
 ## Multi-study manifests
 
-In the case of a manifest that includes multiple studies, the optional `st`
+In the case of a manifest that includes multiple studies, the optional `study` argument can be used to group samples by study and randomized the samples within the study. In the example below, "Site" is used as a surrogate for study. After randomization the sites are kept together across the plates.
+
+```{r}
+randomized.manifest_c <- olink_plate_randomizer(manifest, study = "Site")
+olink_displayPlateLayout(randomized.manifest_c, fill.color = "Site")
+```
+
 
 ## Visualization
 

--- a/OlinkAnalyze/vignettes/plate_randomizer.Rmd
+++ b/OlinkAnalyze/vignettes/plate_randomizer.Rmd
@@ -113,6 +113,10 @@ randomized_manifest %>%
 
 ```
 
+## Multi-study manifests
+
+In the case of a manifest that includes multiple studies, the optional `st`
+
 ## Visualization
 
 To illustrate the goodness of randomization, both `olink_displayPlateLayout()` and `olink_displayPlateDistributions` functions could be used.


### PR DESCRIPTION
# Title: Adding documentation and argument for within study randomization
**Problem:** If "study" column was present within manifest then within study randomization would be performed. However there was no way to set a different column to randomize within.

**Solution:** Study argument was added and defaulted to NULL. Documentation was added to function and tutorial.

**Key Features:**

* `study` argument added to olink_plate_randomizer
* if "study" column is in manifest and `study` argument is not specified, `study` argument will be set to "study" (to preserve backwards compatibility
* A section on Multi-study manifests was added to the plate randomizer tutorial.
* Function documentation was updated to include `study` argument and to add information about within study randomization

## Checklist
- [x] Make sure you are requesting to **pull a feature/bugfix branch** (right side). This should not be main or develop.
- [x] Make sure you are make a pull request against either **main or develop** (left side). (Requesting to main should be reserved for bugfixes and new releases)
- [ ] Add or update unit tests (if applicable)
- [x] Check your code with any unit tests (Run devtools::check() locally)
- [x] Add neccessary documentation (if applicable)

## Type of changes

What type of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue) (link the issue on the right)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code style update (formatting, renaming)
- [x] Documentation Update 
- [ ] Other (explain)

## Further comments
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, any questions you have, etc...

Consider linking any issues (#issue-number ) or adding @mentions to ensure specific people see it.
