### PR TITLE
Fix internal control error in olink_anova

### DIFF
--- a/OlinkAnalyze/R/Olink_anova.R
+++ b/OlinkAnalyze/R/Olink_anova.R
@@ -112,22 +112,24 @@ olink_anova <- function(df,
   if ("AssayType" %in% names(df)) {
     if (any(df$AssayType != "assay")) {
       ctrl_assays <- df |>
-        dplyr::filter(AssayType != "assay")
-      
+        dplyr::filter(.data[["AssayType"]] != "assay")
+
       stop(paste0('Control assays have not been removed from the dataset.\n  Assays with AssayType != "assay" should be excluded.\n  The following ', length(unique(ctrl_assays$Assay)) ,' control assays were found:\n  ',
                   paste(strwrap(toString(unique(ctrl_assays$Assay)), width = 80), collapse = "\n")))
     }
-  } else if (any(stringr::str_detect(df$Assay, stringr::regex("control|ctrl", ignore_case = TRUE)))) {
+  } else {
     ctrl_assays <- df |>
-      dplyr::filter(stringr::str_detect(df$Assay, stringr::regex("control|ctrl", ignore_case = TRUE)))
-    
-    stop(paste0('Control assays have not been removed from the dataset.\n  Assays with "control" in their Assay field should be excluded.\n  The following ', length(unique(ctrl_assays$Assay)) ,' control assays were found:\n  ',
+      dplyr::filter(stringr::str_detect(.data[["Assay"]], stringr::regex("(?i)(?=.*\\bcontrol|ctrl\\b)(?!.*\\bCTRL\\b)")))
+
+    if (nrow(ctrl_assays) > 0) {
+      stop(paste0('Control assays have not been removed from the dataset.\n  Assays with "control" in their Assay field should be excluded.\n  The following ', length(unique(ctrl_assays$Assay)) ,' control assays were found:\n  ',
                 paste(strwrap(toString(unique(ctrl_assays$Assay)), width = 80), collapse = "\n")))
+    }
   }
-  
-  
+
+
   withCallingHandlers({
-    
+
     #Filtering on valid OlinkID
     df <- df |>
       dplyr::filter(stringr::str_detect(OlinkID,
@@ -294,7 +296,7 @@ olink_anova <- function(df,
       dplyr::group_modify(~ internal_anova(x = .x,
           formula_string = formula_string,
           fact.vars = fact.vars))|>
-      dplyr::ungroup()|> 
+      dplyr::ungroup()|>
       dplyr::filter(!term %in% c('(Intercept)','Residuals')) |>
       dplyr::mutate(covariates = term %in% covariate_filter_string) |>
       dplyr::group_by(covariates) |>
@@ -467,26 +469,25 @@ olink_anova_posthoc <- function(df,
   if ("AssayType" %in% names(df)) {
     if (any(df$AssayType != "assay")) {
       ctrl_assays <- df |>
-        dplyr::filter(AssayType != "assay")
-      
-      stop(paste0(
-        'Control assays have not been removed from the dataset.\n  Assays with AssayType != "assay" should be excluded.\n  The following ', length(unique(ctrl_assays$Assay)), " control assays were found:\n  ",
-        paste(strwrap(toString(unique(ctrl_assays$Assay)), width = 80), collapse = "\n")
-      ))
+        dplyr::filter(.data[["AssayType"]] != "assay")
+
+      stop(paste0('Control assays have not been removed from the dataset.\n  Assays with AssayType != "assay" should be excluded.\n  The following ', length(unique(ctrl_assays$Assay)) ,' control assays were found:\n  ',
+                  paste(strwrap(toString(unique(ctrl_assays$Assay)), width = 80), collapse = "\n")))
     }
-  } else if (any(stringr::str_detect(df$Assay, stringr::regex("control|ctrl", ignore_case = TRUE)))) {
+  } else {
     ctrl_assays <- df |>
-      dplyr::filter(stringr::str_detect(df$Assay, stringr::regex("control|ctrl", ignore_case = TRUE)))
-    
-    stop(paste0(
-      'Control assays have not been removed from the dataset.\n  Assays with "control" in their Assay field should be excluded.\n  The following ', length(unique(ctrl_assays$Assay)), " control assays were found:\n  ",
-      paste(strwrap(toString(unique(ctrl_assays$Assay)), width = 80), collapse = "\n")
-    ))
+      dplyr::filter(stringr::str_detect(.data[["Assay"]], stringr::regex("(?i)(?=.*\\bcontrol|ctrl\\b)(?!.*\\bCTRL\\b)")))
+
+
+    if (nrow(ctrl_assays) > 0) {
+      stop(paste0('Control assays have not been removed from the dataset.\n  Assays with "control" in their Assay field should be excluded.\n  The following ', length(unique(ctrl_assays$Assay)) ,' control assays were found:\n  ',
+                  paste(strwrap(toString(unique(ctrl_assays$Assay)), width = 80), collapse = "\n")))
+    }
   }
 
-  
+
   withCallingHandlers({
-    
+
     #Filtering on valid OlinkID
     df <- df |>
       dplyr::filter(stringr::str_detect(OlinkID,


### PR DESCRIPTION
# Title: Fix internal control error in olink_anova 
**Problem:** Error for internal controls in olink_anova is triggered by the CTRL protein assay

**Solution:** Edited the regex to not capture CTRL, but continue to capture case-insensitive "control" or "ctrl" as part of a longer string. Updated tests to ensure CTRL is not included in the list of internal controls found.

## Checklist
- [x] Make sure you are requesting to **pull a feature/bugfix branch** (right side). This should not be main or develop.
- [x] Make sure you are make a pull request against either **main or develop** (left side). (Requesting to main should be reserved for bugfixes and new releases)
- [x] Add or update unit tests (if applicable)
- [x] Check your code with any unit tests (Run devtools::check() locally)
- [ ] Add neccessary documentation (if applicable)

## Type of changes

What type of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue) (link the issue on the right)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Documentation Update 
- [ ] Other (explain)
