### PR TITLE
Fix CI for fgsea

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -39,10 +39,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       
-      - name: Update runner packages
-        if: ${{ startsWith(matrix.os, 'ubuntu') }}      
-        run: |
-          sudo apt-get update && sudo apt-get -y dist-upgrade
+      # - name: Update runner packages
+      #   if: ${{ startsWith(matrix.os, 'ubuntu') }}      
+      #   run: |
+      #     sudo apt-get update && sudo apt-get -y dist-upgrade
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -53,12 +53,12 @@ jobs:
         with:
           pandoc-version: '2.18'      
           
-      - name: Set BioC version
-        run: |
-          install.packages("remotes")
-          forenv <- paste("R_BIOC_VERSION=", as.character(remotes::bioc_version()), sep = "")
-          write(forenv, file = Sys.getenv("GITHUB_ENV"), append = TRUE) # Store current value to ENV          
-        shell: Rscript {0}
+      # - name: Set BioC version
+      #   run: |
+      #     install.packages("remotes")
+      #     forenv <- paste("R_BIOC_VERSION=", as.character(remotes::bioc_version()), sep = "")
+      #     write(forenv, file = Sys.getenv("GITHUB_ENV"), append = TRUE) # Store current value to ENV          
+      #   shell: Rscript {0}
       
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -39,11 +39,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       
-      # - name: Update runner packages
-      #   if: ${{ startsWith(matrix.os, 'ubuntu') }}      
-      #   run: |
-      #     sudo apt-get update && sudo apt-get -y dist-upgrade
-
       - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.r }}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -62,7 +62,7 @@ jobs:
       
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          cache: false
+          # cache: false
           working-directory: OlinkAnalyze
           extra-packages: any::rcmdcheck, pillar
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -50,7 +50,6 @@ jobs:
           
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          # cache: false
           working-directory: OlinkAnalyze
           extra-packages: any::rcmdcheck, pillar
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -53,13 +53,6 @@ jobs:
         with:
           pandoc-version: '2.18'      
           
-      # - name: Set BioC version
-      #   run: |
-      #     install.packages("remotes")
-      #     forenv <- paste("R_BIOC_VERSION=", as.character(remotes::bioc_version()), sep = "")
-      #     write(forenv, file = Sys.getenv("GITHUB_ENV"), append = TRUE) # Store current value to ENV          
-      #   shell: Rscript {0}
-      
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           # cache: false

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -38,6 +38,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      
+      - name: Update runner packages
+        if: ${{ startsWith(matrix.os, 'ubuntu') }}      
+        run: |
+          sudo apt-get update && sudo apt-get -y dist-upgrade
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/.github/workflows/matrix_config_check.json
+++ b/.github/workflows/matrix_config_check.json
@@ -12,7 +12,7 @@
    {
       "os": "ubuntu-20.04",
       "r": "release",
-      "runOn": "always"
+      "runOn": "pull_request"
    },
    {
       "os": "ubuntu-22.04",

--- a/.github/workflows/matrix_config_check.json
+++ b/.github/workflows/matrix_config_check.json
@@ -2,15 +2,35 @@
    {
       "os": "macOS-latest",
       "r": "release",
-      "runOn": "pull_request"
+      "runOn": "always"
    },
    {
       "os": "windows-latest",
       "r": "release",
-      "runOn": "pull_request"
+      "runOn": "always"
+   },
+   {
+      "os": "ubuntu-20.04",
+      "r": "release",
+      "runOn": "always"
    },
    {
       "os": "ubuntu-22.04",
+      "r": "release",
+      "runOn": "always"
+   },
+   {
+      "os": "ubuntu-22.04",
+      "r": "devel",
+      "runOn": "always"
+   },
+   {
+      "os": "ubuntu-24.04",
+      "r": "devel",
+      "runOn": "always"
+   },
+   {
+      "os": "ubuntu-24.04",
       "r": "release",
       "runOn": "always"
    }

--- a/.github/workflows/matrix_config_check.json
+++ b/.github/workflows/matrix_config_check.json
@@ -20,8 +20,13 @@
       "runOn": "always"
    },
    {
-      "os": "ubuntu-22.04",
+      "os": "ubuntu-24.04",
       "r": "devel",
+      "runOn": "always"
+   },
+   {
+      "os": "ubuntu-24.04",
+      "r": "release",
       "runOn": "always"
    }
 ]

--- a/.github/workflows/matrix_config_check.json
+++ b/.github/workflows/matrix_config_check.json
@@ -22,7 +22,7 @@
    {
       "os": "ubuntu-24.04",
       "r": "devel",
-      "runOn": "always"
+      "runOn": "pull_request"
    },
    {
       "os": "ubuntu-24.04",

--- a/.github/workflows/matrix_config_check.json
+++ b/.github/workflows/matrix_config_check.json
@@ -2,7 +2,7 @@
    {
       "os": "macOS-latest",
       "r": "release",
-      "runOn": "always"
+      "runOn": "pull_request"
    },
    {
       "os": "windows-latest",

--- a/.github/workflows/matrix_config_check.json
+++ b/.github/workflows/matrix_config_check.json
@@ -23,15 +23,5 @@
       "os": "ubuntu-22.04",
       "r": "devel",
       "runOn": "always"
-   },
-   {
-      "os": "ubuntu-24.04",
-      "r": "devel",
-      "runOn": "always"
-   },
-   {
-      "os": "ubuntu-24.04",
-      "r": "release",
-      "runOn": "always"
    }
 ]

--- a/.github/workflows/matrix_config_check.json
+++ b/.github/workflows/matrix_config_check.json
@@ -1,27 +1,7 @@
 [
    {
-      "os": "macOS-latest",
-      "r": "release",
-      "runOn": "pull_request"
-   },
-   {
-      "os": "windows-latest",
-      "r": "release",
-      "runOn": "pull_request"
-   },
-   {
-      "os": "ubuntu-20.04",
-      "r": "release",
-      "runOn": "pull_request"
-   },
-   {
       "os": "ubuntu-22.04",
       "r": "release",
       "runOn": "always"
-   },
-   {
-      "os": "ubuntu-22.04",
-      "r": "devel",
-      "runOn": "pull_request"
    }
 ]

--- a/.github/workflows/matrix_config_check.json
+++ b/.github/workflows/matrix_config_check.json
@@ -1,5 +1,15 @@
 [
    {
+      "os": "macOS-latest",
+      "r": "release",
+      "runOn": "pull_request"
+   },
+   {
+      "os": "windows-latest",
+      "r": "release",
+      "runOn": "pull_request"
+   },
+   {
       "os": "ubuntu-22.04",
       "r": "release",
       "runOn": "always"

--- a/.github/workflows/matrix_config_check.json
+++ b/.github/workflows/matrix_config_check.json
@@ -7,7 +7,7 @@
    {
       "os": "windows-latest",
       "r": "release",
-      "runOn": "always"
+      "runOn": "pull_request"
    },
    {
       "os": "ubuntu-20.04",

--- a/.github/workflows/matrix_config_check.json
+++ b/.github/workflows/matrix_config_check.json
@@ -17,7 +17,7 @@
    {
       "os": "ubuntu-22.04",
       "r": "release",
-      "runOn": "always"
+      "runOn": "pull_request"
    },
    {
       "os": "ubuntu-24.04",

--- a/.github/workflows/r-cmd-check-docker.yaml
+++ b/.github/workflows/r-cmd-check-docker.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        r_version: ["4.1.3", "4.2.3", "4.3.3", "4.4.0"]
+        r_version: ["4.1.3", "4.2.3", "4.3.3", "4.4.2"]
     steps:
       -
         name: Checkout

--- a/.github/workflows/render-and-document.yaml
+++ b/.github/workflows/render-and-document.yaml
@@ -30,14 +30,6 @@ jobs:
         with:
           use-public-rspm: true        
           
-      - name: Set BioC version
-        run: |
-          install.packages("remotes")
-          forenv <- paste("R_BIOC_VERSION=", as.character(remotes::bioc_version()), sep = "")
-          write(forenv, file = Sys.getenv("GITHUB_ENV"), append = TRUE) # Store current value to ENV          
-        shell: Rscript {0}
-          
-
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           working-directory: OlinkAnalyze


### PR DESCRIPTION
# Title: Fix CI for fgsea
**Problem:** fgsea wash throwing an error while installing on CI, and workflows were failing.

**Solution:** Installed latest version of BioC instead of its latest registered version on remotes.

**Key Features:**

## Checklist
- [X] Make sure you are requesting to **pull a feature/bugfix branch** (right side). This should not be main or develop.
- [X] Make sure you are make a pull request against either **main or develop** (left side). (Requesting to main should be reserved for bugfixes and new releases)
- [ ] Add or update unit tests (if applicable)
- [X] Check your code with any unit tests (Run devtools::check() locally)
- [ ] Add neccessary documentation (if applicable)

## Type of changes

What type of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue) (link the issue on the right)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Documentation Update 
- [X] Other (CI update)

## Further comments
GitHub will soon start using Ubuntu 24.04 when ubuntu-release is called in CI. I explicitly added Ubuntu 24.04 as the default Ubuntu version in which CI runs always, and moved the check of R devel to Ubuntu 24.04.
Also, the docker image of R 4.4.0 was upgraded to the image of R 4.4.2.
