### PR TITLE
Add Count column check to cross-product bridge normalization

### DIFF
--- a/OlinkAnalyze/R/olink_normalization.R
+++ b/OlinkAnalyze/R/olink_normalization.R
@@ -300,7 +300,7 @@ olink_normalization <- function(df1,
 
     } else if (lst_check$norm_mode == olink_norm_modes$norm_ht_3k) {
       # HT-3K normalization ----
-
+  
       df_norm <- norm_internal_cross_product(
         ref_df = lst_check$ref_df,
         ref_samples = lst_check$ref_samples,
@@ -661,6 +661,51 @@ norm_internal_cross_product <- function(ref_df,
     not_ref_df
   )
   names(lst_df) <- c(ref_name, not_ref_name)
+  
+  # check if both dfs in cross-product normalization contain Count column ----
+  browser()
+  if (!"Count" %in% names(ref_df) && !"Count" %in% names(not_ref_df)) {
+    cli::cli_abort(
+      c(
+        "x" = "No Count column detected in {names(lst_df[1])} and 
+        {names(lst_df[2])}!",
+        "i" = "When performing cross-product normalization, count values are 
+        required in both the new and reference datasets for QS normalization 
+        calculations. Please ensure that the 'Count' column is present in both 
+        {names(lst_df[1])} and {names(lst_df[2])}. Re-export of 
+        {names(lst_df[1])} and/or {names(lst_df[2])} may be required."
+      ),
+      call = rlang::caller_env(),
+      wrap = FALSE
+    )
+    
+  } else if (!"Count" %in% names(ref_df)) {
+    cli::cli_abort(
+      c(
+        "x" = "No Count column detected in {names(lst_df[1])}!",
+        "i" = "When performing cross-product normalization, count values are 
+        required in both the new and reference datasets for QS normalization 
+        calculations. Please ensure that the 'Count' column is present in 
+        {names(lst_df[1])}. Re-export of {names(lst_df[1])} may be required."
+      ),
+      call = rlang::caller_env(),
+      wrap = FALSE
+    )
+    
+  } else if (!"Count" %in% names(not_ref_df)) {
+    cli::cli_abort(
+      c(
+        "x" = "No Count column detected in {names(lst_df[2])}!",
+        "i" = "When performing cross-product normalization, count values are 
+        required in both the new and reference datasets for QS normalization 
+        calculations. Please ensure that the 'Count' column is present in 
+        {names(lst_df[2])}. Re-export of {names(lst_df[2])} may be required."
+      ),
+      call = rlang::caller_env(),
+      wrap = FALSE
+    )
+    
+  }
 
   # is bridgeable ----
 

--- a/OlinkAnalyze/R/olink_normalization.R
+++ b/OlinkAnalyze/R/olink_normalization.R
@@ -669,11 +669,12 @@ norm_internal_cross_product <- function(ref_df,
       c(
         "x" = "No Count column detected in {names(lst_df[1])} and 
         {names(lst_df[2])}!",
-        "i" = "When performing cross-product normalization, count values are 
-        required in both the new and reference datasets for QS normalization 
+        "i" = "When performing cross-product normalization, count values from
+        both the new and reference datasets are required for QS normalization 
         calculations. Please ensure that the 'Count' column is present in both 
         {names(lst_df[1])} and {names(lst_df[2])}. Re-export of 
-        {names(lst_df[1])} and/or {names(lst_df[2])} may be required."
+        {names(lst_df[1])} and/or {names(lst_df[2])} NPX files from Olink data 
+        software  may be required."
       ),
       call = rlang::caller_env(),
       wrap = FALSE
@@ -683,10 +684,11 @@ norm_internal_cross_product <- function(ref_df,
     cli::cli_abort(
       c(
         "x" = "No Count column detected in {names(lst_df[1])}!",
-        "i" = "When performing cross-product normalization, count values are 
-        required in both the new and reference datasets for QS normalization 
-        calculations. Please ensure that the 'Count' column is present in 
-        {names(lst_df[1])}. Re-export of {names(lst_df[1])} may be required."
+        "i" = "When performing cross-product normalization, count values from
+        both the new and reference datasets are required for QS normalization
+        calculations. Please ensure that the 'Count' column is present in
+        {names(lst_df[1])}. Re-export of {names(lst_df[1])} NPX file from Olink 
+        data software  may be required."
       ),
       call = rlang::caller_env(),
       wrap = FALSE
@@ -696,10 +698,11 @@ norm_internal_cross_product <- function(ref_df,
     cli::cli_abort(
       c(
         "x" = "No Count column detected in {names(lst_df[2])}!",
-        "i" = "When performing cross-product normalization, count values are 
-        required in both the new and reference datasets for QS normalization 
-        calculations. Please ensure that the 'Count' column is present in 
-        {names(lst_df[2])}. Re-export of {names(lst_df[2])} may be required."
+        "i" = "When performing cross-product normalization, count values from
+        both the new and reference datasets are required in  for
+        QS normalization calculations. Please ensure that the 'Count' column is 
+        present in {names(lst_df[2])}. Re-export of {names(lst_df[2])} NPX file 
+        from Olink data software  may be required."
       ),
       call = rlang::caller_env(),
       wrap = FALSE

--- a/OlinkAnalyze/R/olink_normalization.R
+++ b/OlinkAnalyze/R/olink_normalization.R
@@ -663,7 +663,7 @@ norm_internal_cross_product <- function(ref_df,
   names(lst_df) <- c(ref_name, not_ref_name)
   
   # check if both dfs in cross-product normalization contain Count column ----
-  browser()
+  
   if (!"Count" %in% names(ref_df) && !"Count" %in% names(not_ref_df)) {
     cli::cli_abort(
       c(

--- a/OlinkAnalyze/R/olink_normalization.R
+++ b/OlinkAnalyze/R/olink_normalization.R
@@ -300,7 +300,7 @@ olink_normalization <- function(df1,
 
     } else if (lst_check$norm_mode == olink_norm_modes$norm_ht_3k) {
       # HT-3K normalization ----
-  
+
       df_norm <- norm_internal_cross_product(
         ref_df = lst_check$ref_df,
         ref_samples = lst_check$ref_samples,
@@ -661,54 +661,6 @@ norm_internal_cross_product <- function(ref_df,
     not_ref_df
   )
   names(lst_df) <- c(ref_name, not_ref_name)
-  
-  # check if both dfs in cross-product normalization contain Count column ----
-  
-  if (!"Count" %in% names(ref_df) && !"Count" %in% names(not_ref_df)) {
-    cli::cli_abort(
-      c(
-        "x" = "No Count column detected in {names(lst_df[1])} and 
-        {names(lst_df[2])}!",
-        "i" = "When performing cross-product normalization, count values from
-        both the new and reference datasets are required for QS normalization 
-        calculations. Please ensure that the 'Count' column is present in both 
-        {names(lst_df[1])} and {names(lst_df[2])}. Re-export of 
-        {names(lst_df[1])} and/or {names(lst_df[2])} NPX files from Olink data 
-        software  may be required."
-      ),
-      call = rlang::caller_env(),
-      wrap = FALSE
-    )
-    
-  } else if (!"Count" %in% names(ref_df)) {
-    cli::cli_abort(
-      c(
-        "x" = "No Count column detected in {names(lst_df[1])}!",
-        "i" = "When performing cross-product normalization, count values from
-        both the new and reference datasets are required for QS normalization
-        calculations. Please ensure that the 'Count' column is present in
-        {names(lst_df[1])}. Re-export of {names(lst_df[1])} NPX file from Olink 
-        data software  may be required."
-      ),
-      call = rlang::caller_env(),
-      wrap = FALSE
-    )
-    
-  } else if (!"Count" %in% names(not_ref_df)) {
-    cli::cli_abort(
-      c(
-        "x" = "No Count column detected in {names(lst_df[2])}!",
-        "i" = "When performing cross-product normalization, count values from
-        both the new and reference datasets are required in  for
-        QS normalization calculations. Please ensure that the 'Count' column is 
-        present in {names(lst_df[2])}. Re-export of {names(lst_df[2])} NPX file 
-        from Olink data software  may be required."
-      ),
-      call = rlang::caller_env(),
-      wrap = FALSE
-    )
-    
-  }
 
   # is bridgeable ----
 

--- a/OlinkAnalyze/R/olink_normalization_utils.R
+++ b/OlinkAnalyze/R/olink_normalization_utils.R
@@ -1001,6 +1001,40 @@ olink_norm_input_cross_product <- function(lst_df,
 
   }
 
+  # check if both dfs in cross-product normalization contain Count column ----
+  
+  if (norm_mode == olink_norm_modes$norm_ht_3k
+      && !"Count" %in% lst_df[1]) {
+    cli::cli_abort(
+      c(
+        "x" = "No Count column detected in {names(lst_df[1])}!",
+        "i" = "When performing cross-product normalization, count values are 
+        required for QS normalization calculations. Please ensure that the 
+        'Count' column is present in {names(lst_df[1])}. Re-export of 
+        {names(lst_df[1])} may be required."
+      ),
+      call = rlang::caller_env(),
+      wrap = FALSE
+    )
+    
+  }
+  if (norm_mode == olink_norm_modes$norm_ht_3k
+      && !"Count" %in% lst_df[2]) {
+    browser()
+    cli::cli_abort(
+      c(
+        "x" = "No Count column detected in {names(lst_df[2])}!",
+        "i" = "When performing cross-product normalization, count values are 
+        required for QS normalization calculations. Please ensure that the 
+        'Count' column is present in {names(lst_df[2])}. Re-export of 
+        {names(lst_df[2])} may be required."
+      ),
+      call = rlang::caller_env(),
+      wrap = FALSE
+    )
+    
+  }
+  
   # update Olink assay identifiers if cross product normalization ----
 
   if (norm_mode == olink_norm_modes$norm_ht_3k) {

--- a/OlinkAnalyze/R/olink_normalization_utils.R
+++ b/OlinkAnalyze/R/olink_normalization_utils.R
@@ -101,7 +101,7 @@ olink_norm_input_check <- function(df1,
                                    reference_project,
                                    reference_medians) {
   # Validate the normalization input ----
-
+  # browser()
   norm_valid <- olink_norm_input_validate(
     df1 = df1,
     df2 = df2,
@@ -1000,41 +1000,7 @@ olink_norm_input_cross_product <- function(lst_df,
     )
 
   }
-
-  # check if both dfs in cross-product normalization contain Count column ----
-  
-  if (norm_mode == olink_norm_modes$norm_ht_3k
-      && !"Count" %in% lst_df[1]) {
-    cli::cli_abort(
-      c(
-        "x" = "No Count column detected in {names(lst_df[1])}!",
-        "i" = "When performing cross-product normalization, count values are 
-        required for QS normalization calculations. Please ensure that the 
-        'Count' column is present in {names(lst_df[1])}. Re-export of 
-        {names(lst_df[1])} may be required."
-      ),
-      call = rlang::caller_env(),
-      wrap = FALSE
-    )
-    
-  }
-  if (norm_mode == olink_norm_modes$norm_ht_3k
-      && !"Count" %in% lst_df[2]) {
-    browser()
-    cli::cli_abort(
-      c(
-        "x" = "No Count column detected in {names(lst_df[2])}!",
-        "i" = "When performing cross-product normalization, count values are 
-        required for QS normalization calculations. Please ensure that the 
-        'Count' column is present in {names(lst_df[2])}. Re-export of 
-        {names(lst_df[2])} may be required."
-      ),
-      call = rlang::caller_env(),
-      wrap = FALSE
-    )
-    
-  }
-  
+ 
   # update Olink assay identifiers if cross product normalization ----
 
   if (norm_mode == olink_norm_modes$norm_ht_3k) {
@@ -1205,7 +1171,7 @@ olink_norm_input_cross_product <- function(lst_df,
 olink_norm_input_check_samples <- function(lst_df_samples,
                                            lst_ref_samples,
                                            norm_mode) {
-
+  
   if (!(length(lst_df_samples) %in% c(1L, 2L))) {
     # if 0 or more than 2 datasets are provided
     cli::cli_abort(

--- a/OlinkAnalyze/R/olink_normalization_utils.R
+++ b/OlinkAnalyze/R/olink_normalization_utils.R
@@ -101,7 +101,7 @@ olink_norm_input_check <- function(df1,
                                    reference_project,
                                    reference_medians) {
   # Validate the normalization input ----
-  # browser()
+  
   norm_valid <- olink_norm_input_validate(
     df1 = df1,
     df2 = df2,

--- a/OlinkAnalyze/tests/testthat/test-olink_normalization.R
+++ b/OlinkAnalyze/tests/testthat/test-olink_normalization.R
@@ -470,7 +470,7 @@ test_that(
 test_that(
   "olink_normalization - works - 3k-HT normalization",
   {
-    
+
     skip_if_not(file.exists(test_path("data","example_3k_data.rds")))
     skip_if_not(file.exists(test_path("data","example_HT_data.rds")))
 
@@ -509,6 +509,7 @@ test_that(
                    "MedianCenteredNPX", "QSNormalizedNPX",
                    "BridgingRecommendation")
     )
+
   }
 )
 
@@ -789,5 +790,63 @@ test_that(
         dplyr::pull(),
       expected = oid_3k
     )
+  }
+)
+
+test_that(
+  "norm_internal_cross_product missing counts - error",
+  {
+    
+    skip_if_not(file.exists(test_path("data","example_3k_data.rds")))
+    skip_if_not(file.exists(test_path("data","example_HT_data.rds")))
+    
+    data_3k <- get_example_data(filename = "example_3k_data.rds")
+    data_ht <- get_example_data(filename = "example_HT_data.rds")
+    
+    ## error v1: reference/HT and new/3K DF missing count column ----
+    
+    expect_error(
+      object = norm_internal_cross_product(
+        ref_df = data_ht |> select(-Count),
+        ref_samples = intersect(data_ht$SampleID, data_3k$SampleID),
+        ref_name= "proj_ht",
+        ref_cols = colnames(data_ht),
+        not_ref_df = data_3k |> select(-Count),
+        not_ref_name = "proj_3k",
+        not_ref_cols = colnames(data_3k)
+      ),
+      regexp = paste("No Count column detected in proj_ht and proj_3k!")
+    )
+
+    ## error v2: reference/HT DF missing count column ----
+    
+    expect_error(
+      object = norm_internal_cross_product(
+        ref_df = data_ht |> select(-Count),
+        ref_samples = intersect(data_ht$SampleID, data_3k$SampleID),
+        ref_name= "proj_ht",
+        ref_cols = colnames(data_ht),
+        not_ref_df = data_3k,
+        not_ref_name = "proj_3k",
+        not_ref_cols = colnames(data_3k)
+      ),
+      regexp = paste("No Count column detected in proj_ht!")
+    )
+      
+    ## error v3: new/3K DF missing count column ----
+
+    expect_error(
+      object = norm_internal_cross_product(
+        ref_df = data_ht,
+        ref_samples = intersect(data_ht$SampleID, data_3k$SampleID),
+        ref_name= "proj_ht",
+        ref_cols = colnames(data_ht),
+        not_ref_df = data_3k |> select(-Count),
+        not_ref_name = "proj_3k",
+        not_ref_cols = colnames(data_3k)
+      ),
+      regexp = paste("No Count column detected in proj_3k!")
+    )
+
   }
 )

--- a/OlinkAnalyze/tests/testthat/test-olink_normalization_utils.R
+++ b/OlinkAnalyze/tests/testthat/test-olink_normalization_utils.R
@@ -46,7 +46,8 @@ test_that(
                         assay_warn = character(0L),
                         quant = "NPX",
                         lod = "LOD",
-                        normalization = character(0L)),
+                        normalization = character(0L),
+                        count = character(0L)),
         not_ref_df = npx_data2,
         not_ref_samples = NULL,
         not_ref_name = "20200002",
@@ -61,7 +62,8 @@ test_that(
                             assay_warn = character(0L),
                             quant = "NPX",
                             lod = "LOD",
-                            normalization = character(0L)),
+                            normalization = character(0L),
+                            count = character(0L)),
         reference_medians = NULL,
         norm_mode = olink_norm_modes$bridge
       )
@@ -113,7 +115,8 @@ test_that(
                         assay_warn = character(0L),
                         quant = "NPX",
                         lod = "LOD",
-                        normalization = "Normalization"),
+                        normalization = "Normalization",
+                        count = character(0L)),
         not_ref_df = npx_data1 |>
           dplyr::mutate(
             Normalization = "Intensity"
@@ -131,7 +134,8 @@ test_that(
                             assay_warn = character(0L),
                             quant = "NPX",
                             lod = "LOD",
-                            normalization = "Normalization"),
+                            normalization = "Normalization",
+                            count = character(0L)),
         reference_medians = NULL,
         norm_mode = olink_norm_modes$bridge
       )
@@ -208,7 +212,8 @@ test_that(
                         assay_warn = "AssayQC",
                         quant = "NPX",
                         lod = character(0),
-                        normalization = "Normalization"),
+                        normalization = "Normalization",
+                        count = "Count"),
         not_ref_df = data_3k |>
           dplyr::rename(
             "OlinkID_E3072" = "OlinkID"
@@ -241,7 +246,8 @@ test_that(
                             assay_warn = "AssayQC",
                             quant = "NPX",
                             lod = character(0),
-                            normalization = "Normalization"),
+                            normalization = "Normalization",
+                            count = "Count"),
         reference_medians = NULL,
         norm_mode = olink_norm_modes$norm_ht_3k
       )
@@ -291,7 +297,8 @@ test_that(
                         assay_warn = character(0L),
                         quant = "NPX",
                         lod = "LOD",
-                        normalization = character(0L)),
+                        normalization = character(0L),
+                        count = character(0L)),
         not_ref_df = npx_data2,
         not_ref_samples = unique(npx_data2$SampleID),
         not_ref_name = "20200002",
@@ -306,7 +313,8 @@ test_that(
                             assay_warn = character(0L),
                             quant = "NPX",
                             lod = "LOD",
-                            normalization = character(0L)),
+                            normalization = character(0L),
+                            count = character(0L)),
         reference_medians = NULL,
         norm_mode = olink_norm_modes$subset
       )
@@ -354,7 +362,8 @@ test_that(
                         assay_warn = character(0L),
                         quant = "NPX",
                         lod = "LOD",
-                        normalization = "Normalization"),
+                        normalization = "Normalization",
+                        count = character(0L)),
         not_ref_df = npx_data1 |>
           dplyr::mutate(
             Normalization = "Intensity"
@@ -372,7 +381,8 @@ test_that(
                             assay_warn = character(0L),
                             quant = "NPX",
                             lod = "LOD",
-                            normalization = "Normalization"),
+                            normalization = "Normalization",
+                            count = character(0L)),
         reference_medians = NULL,
         norm_mode = olink_norm_modes$subset
       )
@@ -427,7 +437,8 @@ test_that(
                         assay_warn = character(0L),
                         quant = "NPX",
                         lod = "LOD",
-                        normalization = character(0L)),
+                        normalization = character(0L),
+                        count = character(0L)),
         not_ref_df = npx_data2,
         not_ref_samples = npx_df2_samples,
         not_ref_name = "20200002",
@@ -442,7 +453,8 @@ test_that(
                             assay_warn = character(0L),
                             quant = "NPX",
                             lod = "LOD",
-                            normalization = character(0L)),
+                            normalization = character(0L),
+                            count = character(0L)),
         reference_medians = NULL,
         norm_mode = olink_norm_modes$subset
       )
@@ -490,7 +502,8 @@ test_that(
                         assay_warn = character(0L),
                         quant = "NPX",
                         lod = "LOD",
-                        normalization = "Normalization"),
+                        normalization = "Normalization",
+                        count = character(0L)),
         not_ref_df = npx_data1 |>
           dplyr::mutate(
             Normalization = "Intensity"
@@ -508,7 +521,8 @@ test_that(
                             assay_warn = character(0L),
                             quant = "NPX",
                             lod = "LOD",
-                            normalization = "Normalization"),
+                            normalization = "Normalization",
+                            count = character(0L)),
         reference_medians = NULL,
         norm_mode = olink_norm_modes$subset
       )
@@ -574,7 +588,8 @@ test_that(
                         assay_warn = character(0L),
                         quant = "NPX",
                         lod = "LOD",
-                        normalization = character(0L)),
+                        normalization = character(0L),
+                        count = character(0L)),
         not_ref_df = NULL,
         not_ref_samples = NULL,
         not_ref_name = NULL,
@@ -626,7 +641,8 @@ test_that(
                         assay_warn = character(0L),
                         quant = "NPX",
                         lod = "LOD",
-                        normalization = "Normalization"),
+                        normalization = "Normalization",
+                        count = character(0L)),
         not_ref_df = NULL,
         not_ref_samples = NULL,
         not_ref_name = NULL,
@@ -1546,7 +1562,8 @@ test_that(
           assay_warn = character(0L),
           quant = "NPX",
           lod = "LOD",
-          normalization = character(0L)
+          normalization = character(0L),
+          count = character(0L)
         )
       )
     )
@@ -1584,7 +1601,8 @@ test_that(
           assay_warn = character(0L),
           quant = "NPX",
           lod = "LOD",
-          normalization = character(0L)
+          normalization = character(0L),
+          count = character(0L)
         )
       )
     )
@@ -1624,7 +1642,8 @@ test_that(
           assay_warn = character(0L),
           quant = "NPX",
           lod = "LOD",
-          normalization = "Normalization"
+          normalization = "Normalization",
+          count = character(0L)
         )
       )
     )
@@ -1665,7 +1684,8 @@ test_that(
           assay_warn = character(0L),
           quant = "NPX",
           lod = "LOD",
-          normalization = "Normalization"
+          normalization = "Normalization",
+          count = character(0L)
         )
       )
     )
@@ -1710,7 +1730,8 @@ test_that(
           assay_warn = character(0L),
           quant = "NPX",
           lod = "LOD",
-          normalization = character(0L)
+          normalization = character(0L),
+          count = character(0L)
         ),
         "p2" = list(
           sample_id = "SampleID",
@@ -1724,7 +1745,8 @@ test_that(
           assay_warn = character(0L),
           quant = "NPX",
           lod = "LOD",
-          normalization = character(0L)
+          normalization = character(0L),
+          count = character(0L)
         )
       )
     )
@@ -1765,7 +1787,8 @@ test_that(
           assay_warn = character(0L),
           quant = "NPX",
           lod = "LOD",
-          normalization = "Normalization"
+          normalization = "Normalization",
+          count = character(0L)
         ),
         "p2" = list(
           sample_id = "SampleID",
@@ -1779,7 +1802,8 @@ test_that(
           assay_warn = character(0L),
           quant = "NPX",
           lod = "LOD",
-          normalization = "Normalization"
+          normalization = "Normalization",
+          count = character(0L)
         )
       )
     )
@@ -1816,7 +1840,8 @@ test_that(
           assay_warn = character(0L),
           quant = "NPX",
           lod = "LOD",
-          normalization = "Normalization"
+          normalization = "Normalization",
+          count = character(0L)
         ),
         "p2" = list(
           sample_id = "SampleID",
@@ -1830,7 +1855,8 @@ test_that(
           assay_warn = character(0L),
           quant = "NPX",
           lod = "LOD",
-          normalization = "Normalization"
+          normalization = "Normalization",
+          count = character(0L)
         )
       )
     )
@@ -1936,7 +1962,8 @@ test_that(
           assay_warn = character(0L),
           quant = "NPX",
           lod = "LOD",
-          normalization = "Normalization"
+          normalization = "Normalization",
+          count = character(0L)
         ),
         "p2" = list(
           sample_id = "SampleID",
@@ -1950,7 +1977,8 @@ test_that(
           assay_warn = character(0L),
           quant = "NPX",
           lod = "LOD",
-          normalization = "Normalization"
+          normalization = "Normalization",
+          count = character(0L)
         ),
         "p3" = list(
           sample_id = "SampleID",
@@ -1964,7 +1992,8 @@ test_that(
           assay_warn = character(0L),
           quant = "NPX",
           lod = "LOD",
-          normalization = "Normalization"
+          normalization = "Normalization",
+          count = character(0L)
         ),
         "p4" = list(
           sample_id = "SampleID",
@@ -1978,7 +2007,8 @@ test_that(
           assay_warn = character(0L),
           quant = "NPX",
           lod = "LOD",
-          normalization = "Normalization"
+          normalization = "Normalization",
+          count = character(0L)
         )
       )
     )
@@ -2011,7 +2041,8 @@ test_that(
           assay_warn = character(0L),
           quant = "NPX",
           lod = "LOD",
-          normalization = character(0L)
+          normalization = character(0L),
+          count = character(0L)
         ),
         "p2" = list(
           sample_id = "SampleID",
@@ -2025,7 +2056,8 @@ test_that(
           assay_warn = character(0L),
           quant = "NPX",
           lod = "LOD",
-          normalization = character(0L)
+          normalization = character(0L),
+          count = character(0L)
         ),
         "p3" = list(
           sample_id = "SampleID",
@@ -2039,7 +2071,8 @@ test_that(
           assay_warn = character(0L),
           quant = "NPX",
           lod = "LOD",
-          normalization = character(0L)
+          normalization = character(0L),
+          count = character(0L)
         ),
         "p4" = list(
           sample_id = "SampleID",
@@ -2053,7 +2086,8 @@ test_that(
           assay_warn = character(0L),
           quant = "NPX",
           lod = "LOD",
-          normalization = character(0L)
+          normalization = character(0L),
+          count = character(0L)
         )
       )
     )
@@ -2124,6 +2158,89 @@ test_that(
         regexp = "Datasets \"p1\" and \"p2\" contain multiple columns matching"
       ),
       regexp = "* p1: MaxLOD"
+    )
+  }
+)
+
+test_that(
+  "olink_norm_input_check_df_cols - message - non-required columns",
+  {
+    skip_if_not_installed("arrow")
+
+    # df has assay_warn ----
+
+    expect_warning(
+      object = lst_col <- olink_norm_input_check_df_cols(
+        lst_df = list(
+          "p1" = npx_data1
+        ) |>
+          lapply(function(l_df) {
+            l_df |>
+              dplyr::mutate(
+                Assay_Warning = NA_character_
+              )
+          })
+      ),
+      regexp = "Dataset \"p1\" does not contain a column named"
+    )
+
+    expect_identical(
+      object = lst_col,
+      expected = list(
+        "p1" = list(
+          sample_id = "SampleID",
+          olink_id = "OlinkID",
+          uniprot = "UniProt",
+          assay = "Assay",
+          panel = "Panel",
+          panel_version = "Panel_Version",
+          plate_id = "PlateID",
+          qc_warn = "QC_Warning",
+          assay_warn = "Assay_Warning",
+          quant = "NPX",
+          lod = "LOD",
+          normalization = character(0L),
+          count = character(0L)
+        )
+      )
+    )
+
+    # df has Count ----
+
+    expect_warning(
+      object = lst_col <- olink_norm_input_check_df_cols(
+        lst_df = list(
+          "p1" = npx_data1
+        ) |>
+          lapply(function(l_df) {
+            l_df |>
+              dplyr::mutate(
+                Count = NA_integer_
+              )
+          })
+      ),
+      regexp = "Dataset \"p1\" does not contain a column named"
+    )
+
+    expect_identical(
+      object = lst_col,
+      expected = list(
+        "p1" = list(
+          sample_id = "SampleID",
+          olink_id = "OlinkID",
+          uniprot = "UniProt",
+          assay = "Assay",
+          panel = "Panel",
+          panel_version = "Panel_Version",
+          plate_id = "PlateID",
+          qc_warn = "QC_Warning",
+          assay_warn = character(0L),
+          quant = "NPX",
+          lod = "LOD",
+          normalization = character(0L),
+          count = "Count"
+        )
+      )
     )
   }
 )
@@ -2534,9 +2651,11 @@ test_that(
         ),
         lst_cols = list(
           "p1" = list(panel = "Panel",
-                      olink_id = "OlinkID"),
+                      olink_id = "OlinkID",
+                      count = "Count"),
           "p2" = list(panel = "Panel",
-                      olink_id = "OlinkID")
+                      olink_id = "OlinkID",
+                      count = "Count")
         ),
         reference_project = "p2"
       )
@@ -2661,6 +2780,78 @@ test_that(
         reference_project = "3K"
       ),
       regexp = "Incorrect reference project!"
+    )
+  }
+)
+
+test_that(
+  "olink_norm_input_cross_product - error - missing count col",
+  {
+    skip_if_not_installed("arrow")
+
+    skip_if_not(file.exists(test_path("data","example_3k_data.rds")))
+    skip_if_not(file.exists(test_path("data","example_HT_data.rds")))
+
+    data_3k <- get_example_data(filename = "example_3k_data.rds")
+    data_ht <- get_example_data(filename = "example_HT_data.rds")
+
+    # missing from p1
+
+    expect_error(
+      object = olink_norm_input_cross_product(
+        lst_df = list(
+          "p1" = data_3k,
+          "p2" = data_ht
+        ),
+        lst_cols = list(
+          "p1" = list(panel = "Panel",
+                      olink_id = "OlinkID"),
+          "p2" = list(panel = "Panel",
+                      olink_id = "OlinkID",
+                      count = "Count")
+        ),
+        reference_project = "p2"
+      ),
+      regexp = "Column \"Count\" not found in dataset \"p1\"!"
+    )
+
+    # missing from p2
+
+    expect_error(
+      object = olink_norm_input_cross_product(
+        lst_df = list(
+          "p1" = data_3k,
+          "p2" = data_ht
+        ),
+        lst_cols = list(
+          "p1" = list(panel = "Panel",
+                      olink_id = "OlinkID",
+                      count = "Count"),
+          "p2" = list(panel = "Panel",
+                      olink_id = "OlinkID")
+        ),
+        reference_project = "p2"
+      ),
+      regexp = "Column \"Count\" not found in dataset \"p2\"!"
+    )
+
+    # missing from p1 and p2
+
+    expect_error(
+      object = olink_norm_input_cross_product(
+        lst_df = list(
+          "p1" = data_3k,
+          "p2" = data_ht
+        ),
+        lst_cols = list(
+          "p1" = list(panel = "Panel",
+                      olink_id = "OlinkID"),
+          "p2" = list(panel = "Panel",
+                      olink_id = "OlinkID")
+        ),
+        reference_project = "p2"
+      ),
+      regexp = "Column \"Count\" not found in datasets \"p1\" and \"p2\"!"
     )
   }
 )
@@ -5243,4 +5434,3 @@ test_that(
     )
   }
 )
-


### PR DESCRIPTION
# Add Count column check to cross-product bridge normalization
**Problem:** Provides error with informative text for cross-product bridging when the Count column is missing from either of or both of the datasets. 

**Solution:** Add a check to internal function, norm_internal_cross_product, to ensure that the Count column is present in both dataframes in cross-product normalization. 

**Key Features:**

* Key feature 1: add check that Count column exists in both dataframes used in cross-product bridge normalization
* Key feature 2: add unit test for norm_internal_cross_product to ensure that the error and corresponding text is functioning as expected

## Checklist
- [X] Make sure you are requesting to **pull a feature/bugfix branch** (right side). This should not be main or develop.
- [X] Make sure you are make a pull request against either **main or develop** (left side). (Requesting to main should be reserved for bugfixes and new releases)
- [X] Add or update unit tests (if applicable)
- [X] Check your code with any unit tests (Run devtools::check() locally)
- [ ] Add neccessary documentation (if applicable)

## Type of changes

What type of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue) (link the issue on the right)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Documentation Update 
- [ ] Other (explain)
