### PR TITLE
Add 'devtools' to lint CI workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-         extra-packages: any::pak, any::lintr, local::.
+         extra-packages: any::pak, any::lintr, any::devtools, local::.
          working-directory: OlinkAnalyze
           
       - name: Lint


### PR DESCRIPTION
# Title: Add `devtools` to lint CI workflow
**Problem:** lint CI workflow fails because it cannot find package `devtools` when running.

**Solution:** Added `devtools` to extra-packages.

## Checklist
- [X] Make sure you are requesting to **pull a feature/bugfix branch** (right side). This should not be main or develop.
- [X] Make sure you are make a pull request against either **main or develop** (left side). (Requesting to main should be reserved for bugfixes and new releases)
- [ ] Add or update unit tests (if applicable)
- [X] Check your code with any unit tests (Run devtools::check() locally)
- [ ] Add neccessary documentation (if applicable)

## Type of changes

What type of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue) (link the issue on the right)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Documentation Update 
- [ ] Other (explain)

## Further comments
Due to the 'msigdbr' update from v7.5.1 to v10.0.0 CI will continue failing, but not for lint.
