### PR TITLE
Documentation workflow fails if `roxygenise` fails

### DIFF
--- a/.github/workflows/coverage-render-and-document.yaml
+++ b/.github/workflows/coverage-render-and-document.yaml
@@ -35,7 +35,6 @@ jobs:
 
       - name: Test coverage badge
         run: |
-          set -e
           Rscript -e 'source("test_coverage/update_readme_coverage_badge.R")'
 
       - name: Commit changes if README is updated
@@ -46,7 +45,6 @@ jobs:
 
       - name: Render Rmarkdown files
         run: |
-          set -e
           RMD_PATH=($(find . -iname "*.rmd" | grep -v vignette || echo "No Rmd found"))
           Rscript -e 'for (f in commandArgs(TRUE)) if (file.exists(f)) rmarkdown::render(f)' ${RMD_PATH[*]}
 
@@ -58,7 +56,6 @@ jobs:
 
       - name: Document
         run: |
-          set -e
           Rscript -e 'roxygen2::roxygenise(package.dir = "OlinkAnalyze")'
 
       - name: Commit results

--- a/.github/workflows/coverage-render-and-document.yaml
+++ b/.github/workflows/coverage-render-and-document.yaml
@@ -56,7 +56,24 @@ jobs:
 
       - name: Document
         run: |
-          Rscript -e 'roxygen2::roxygenise(package.dir = "OlinkAnalyze")'
+          # capture output of roxygen2::roxygenise on OlinkAnalyze
+          doc_output <- tryCatch(
+            {
+              capture.output(roxygen2::roxygenise(package.dir = "OlinkAnalyze"), type = "message")
+            },
+            error = function(e) {
+              message("Error: ", e$message)
+              quit(status = 1)
+            }
+          )
+
+          # Check for "✖" symbol in the output, which indicates an issue
+          if (any(grepl("✖", doc_output))) {
+            message("Roxygen2 found documentation issues:\n",
+                    paste(doc_output[grepl("✖", doc_output)], collapse = "\n"))
+            quit(status = 1)
+          }
+        shell: Rscript {0}
 
       - name: Commit results
         run: |


### PR DESCRIPTION
# Title: Documentation workflow fails if `roxygenise` fails
**Problem:** Documentation workflow does not fail when the documentation is rebuilt using `roxygen2::roxygenise`, while it should to signal the issue to the developer.

**Solution:** We tried several solutions, but this one was the only viable. The command `roxygen2::roxygenise`, similarly to `devtools::document`, rebuilds the documentation of the package. Errors in the documentation are printed as messages and neither as warnings or errors, allowing the workflow to function as usual. Our solution is to capture the output message from `roxygen2::roxygenise` and throw an error if the message contains errors.

**Key Features:**

* Documentation using `roxygen2::roxygenise` throws an error if documentation fails.

## Checklist
- [X] Make sure you are requesting to **pull a feature/bugfix branch** (right side). This should not be main or develop.
- [X] Make sure you are make a pull request against either **main or develop** (left side). (Requesting to main should be reserved for bugfixes and new releases)
- [ ] Add or update unit tests (if applicable)
- [X] Check your code with any unit tests (Run devtools::check() locally)
- [ ] Add neccessary documentation (if applicable)

## Type of changes

What type of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue) (link the issue on the right)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Documentation Update 
- [X] CI workflow update

## Further comments
Related to #535.