### PR TITLE
Warning message when running lme

### DIFF
--- a/OlinkAnalyze/R/linear_mixed_model.R
+++ b/OlinkAnalyze/R/linear_mixed_model.R
@@ -307,7 +307,7 @@ olink_lmer <- function(df,
     }
 
   }, warning = function(w) {
-    if (grepl(x = w, pattern = glob2rx("*not recognized or transformed: NumDF, DenDF*")) |
+    if (grepl(x = w, pattern = glob2rx("*not recognized or transformed*")) |
         grepl(x = w, pattern = glob2rx("*contains implicit NA, consider using*"))){
       invokeRestart("muffleWarning")
     }


### PR DESCRIPTION
# Title: Harmless LME warning message causing test warns
**Problem:** when converting anova object to tidy, warning occurs
Warning: The column names NumDF and DenDF in ANOVA output were not recognized or transformed.

**Solution:** previously a check had been written to handle this warning but the warning was reformatted. changed grepl to trigger in both cases.

**Key Features:**

* Key feature 1
* Key feature 2
* ...

## Checklist
- [ ] Make sure you are requesting to **pull a feature/bugfix branch** (right side). This should not be main or develop.
- [ ] Make sure you are make a pull request against either **main or develop** (left side). (Requesting to main should be reserved for bugfixes and new releases)
- [ ] Add or update unit tests (if applicable)
- [ ] Check your code with any unit tests (Run devtools::check() locally)
- [ ] Add neccessary documentation (if applicable)

## Type of changes

What type of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue) (link the issue on the right)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Documentation Update 
- [ ] Other (explain)

## Further comments
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, any questions you have, etc...

Consider linking any issues (#issue-number ) or adding @mentions to ensure specific people see it.
