### PR TITLE
Object 'data' was erroneously referred to as 'df'

### DIFF
--- a/OlinkAnalyze/R/olink_lod.R
+++ b/OlinkAnalyze/R/olink_lod.R
@@ -42,9 +42,9 @@
 #'
 olink_lod <- function(data, lod_file_path = NULL, lod_method = "NCLOD"){
   #Check data format
-  npxCheck <- npxCheck(df)
+  npxCheck <- npxCheck(data)
   # Rename duplicate UniProts
-  df <- uniprot_replace(df, npxCheck)
+  data <- uniprot_replace(data, npxCheck)
 
   # lod_method must be one of options
   if(!lod_method %in% c("NCLOD", "FixedLOD", "Both")){


### PR DESCRIPTION
***Note:** At this time we are unable to accept external contributions. For feature suggestions and any issues, please reach out to biostattools@olink.com.*

# Title: Object 'data' was erroneously referred to as 'df'
**Problem:** In the function olink_lod the object 'data' was erroneously referred to as 'df' causing an error thrown that NPX and Quantified_value are missing.

**Solution:** Replace 'df' with 'data'.

## Checklist
- [X] Make sure you are requesting to **pull a feature/bugfix branch** (right side). This should not be main or develop.
- [X] Make sure you are make a pull request against either **main or develop** (left side). (Requesting to main should be reserved for bugfixes and new releases)
- [ ] Add or update unit tests (if applicable)
- [X] Check your code with any unit tests (Run devtools::check() locally)
- [ ] Add neccessary documentation (if applicable)

## Type of changes

What type of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue) (link the issue on the right)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Documentation Update 
- [ ] Other (explain)

## Further comments
This is a small change addressing a recent bug in OlinkAnalyze. Addressing #578.
