### PR TITLE
Check length of badge_line

### DIFF
--- a/test_coverage/update_readme_coverage_badge.R
+++ b/test_coverage/update_readme_coverage_badge.R
@@ -26,6 +26,11 @@ readme <- readLines("README.Rmd")
 
 # Extract the current badge value
 badge_line <- which(grepl(pattern = "^\\[\\!\\[Coverage\\]", x = readme))
+if (length(badge_line) == 0L) {
+  stop("No coverage badge found in README.Rmd!")
+} else if (length(badge_line) > 1L) {
+  stop("Multiple coverage badges found in README.Rmd!")
+}
 current_badge_url <- stringr::str_extract(string = readme[badge_line],
                                           pattern = "(?<=\\().+?(?=\\))")
 


### PR DESCRIPTION
This pull request adds error handling to the script that updates the coverage badge in the `README.Rmd` file. Now, the script will explicitly stop and display an error if it detects that there are zero or multiple coverage badges, ensuring the badge update process is robust and less prone to silent failures.

Error handling improvements:

* Added checks to stop execution with a clear error message if no coverage badge or multiple coverage badges are found in `README.Rmd` (`test_coverage/update_readme_coverage_badge.R`).
