### PR TITLE
Remove requirement to install Matrix from source

### DIFF
--- a/.github/workflows/CRAN_check.yaml
+++ b/.github/workflows/CRAN_check.yaml
@@ -49,11 +49,6 @@ jobs:
           working-directory: OlinkAnalyze
           extra-packages: any::rcmdcheck, pillar, any::devtools, any::cli, any::rhub, any::revdepcheck, github::r-lib/revdepcheck, any::spelling
 
-      - name: Install Matrix from source
-        run: |
-          install.packages("Matrix", type="source", repos='http://cran.us.r-project.org')
-        shell: Rscript {0}
-
       - name: Record check messages
         if: success() || failure()
         run: |

--- a/.github/workflows/CRAN_check.yaml
+++ b/.github/workflows/CRAN_check.yaml
@@ -1,12 +1,13 @@
 # For help debugging build failures open an issue on the RStudio community with the 'github-actions' tag.
 # https://community.rstudio.com/new-topic?category=Package%20development&tags=github-actions
-on:
-  pull_request:
-    branches:
-      - 'main'
-  push:
-    branches:
-      - 'CRAN*'
+# on:
+#   pull_request:
+#     branches:
+#       - 'main'
+#   push:
+#     branches:
+#       - 'CRAN*'
+on: push
 
 name: CRAN checks
 

--- a/.github/workflows/CRAN_check.yaml
+++ b/.github/workflows/CRAN_check.yaml
@@ -1,13 +1,12 @@
 # For help debugging build failures open an issue on the RStudio community with the 'github-actions' tag.
 # https://community.rstudio.com/new-topic?category=Package%20development&tags=github-actions
-# on:
-#   pull_request:
-#     branches:
-#       - 'main'
-#   push:
-#     branches:
-#       - 'CRAN*'
-on: push
+on:
+  pull_request:
+    branches:
+      - 'main'
+  push:
+    branches:
+      - 'CRAN*'
 
 name: CRAN checks
 


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow for CRAN checks. The main change is the removal of a step that installed the `Matrix` package from source.

* CI Workflow Update:
  * [`.github/workflows/CRAN_check.yaml`](diffhunk://#diff-687c671e10a261b852f9264a659eb25a027901389a230b9af54fc170d623a6b4L52-L56): Removed the step that installs the `Matrix` package from source, because it is no longer necessary for the workflow as it is handled elsewhere.

**NOTE** "coverage-render-and-document" fail because of pathway enrichment updates. We can ignore this failure for now.
