### PR TITLE
Remove rhub dependency and toggle test mode

### DIFF
--- a/.github/workflows/CRAN_check.yaml
+++ b/.github/workflows/CRAN_check.yaml
@@ -1,12 +1,13 @@
 # For help debugging build failures open an issue on the RStudio community with the 'github-actions' tag.
 # https://community.rstudio.com/new-topic?category=Package%20development&tags=github-actions
-on:
-  pull_request:
-    branches:
-      - 'main'
-  push:
-    branches:
-      - 'CRAN*'
+# on:
+#   pull_request:
+#     branches:
+#       - 'main'
+#   push:
+#     branches:
+#       - 'CRAN*'
+on: push
 
 name: CRAN checks
 

--- a/.github/workflows/CRAN_check.yaml
+++ b/.github/workflows/CRAN_check.yaml
@@ -96,15 +96,3 @@ jobs:
         
           revdepcheck::revdep_check()
         shell: Rscript {0}          
-
-      - name: rhub & win-builder checks
-        if: success() # Only use external resources if all other checks passed
-        run: |
-          setwd("OlinkAnalyze")
-        
-          devtools::check_win_devel()
-          
-          rhub::validate_email(email = "biostattools@olink.com", token = "${{ secrets.RHUB_TOKEN }}")
-          stash <- devtools::check_rhub(env_vars = c(`_R_CHECK_FORCE_SUGGESTS_` = "false"), interactive = FALSE)
-        shell: Rscript {0}
-

--- a/.github/workflows/CRAN_check.yaml
+++ b/.github/workflows/CRAN_check.yaml
@@ -47,7 +47,7 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           working-directory: OlinkAnalyze
-          extra-packages: any::rcmdcheck, pillar, any::devtools, any::cli, any::rhub, any::revdepcheck, github::r-lib/revdepcheck, any::spelling
+          extra-packages: any::rcmdcheck, pillar, any::devtools, any::cli, any::revdepcheck, github::r-lib/revdepcheck, any::spelling
 
       - name: Install Matrix from source
         run: |

--- a/.github/workflows/CRAN_check.yaml
+++ b/.github/workflows/CRAN_check.yaml
@@ -1,13 +1,12 @@
 # For help debugging build failures open an issue on the RStudio community with the 'github-actions' tag.
 # https://community.rstudio.com/new-topic?category=Package%20development&tags=github-actions
-# on:
-#   pull_request:
-#     branches:
-#       - 'main'
-#   push:
-#     branches:
-#       - 'CRAN*'
-on: push
+on:
+  pull_request:
+    branches:
+      - 'main'
+  push:
+    branches:
+      - 'CRAN*'
 
 name: CRAN checks
 


### PR DESCRIPTION
This pull request makes minor adjustments to the GitHub Actions workflow for CRAN checks. It removes the use of the `rhub` package and related checks from the workflow, and also cleans up the list of extra R packages to install.

Workflow adjustments:

* Removed `rhub` and win-builder checks from the CRAN check workflow, including the installation and validation steps for `rhub` and the call to `devtools::check_win_devel()`. (`.github/workflows/CRAN_check.yaml`)
* Removed `any::rhub` from the `extra-packages` list in the setup step to avoid unnecessary installation. (`.github/workflows/CRAN_check.yaml`)

**NOTE** "coverage-render-and-document" fail because of pathway enrichment updates. We can ignore this failure for now.