### PR TITLE
Check CRAN status and run revdepcheck in test mode

### DIFF
--- a/.github/workflows/CRAN_check.yaml
+++ b/.github/workflows/CRAN_check.yaml
@@ -1,12 +1,13 @@
 # For help debugging build failures open an issue on the RStudio community with the 'github-actions' tag.
 # https://community.rstudio.com/new-topic?category=Package%20development&tags=github-actions
-on:
-  pull_request:
-    branches:
-      - 'main'
-  push:
-    branches:
-      - 'CRAN*'
+# on:
+#   pull_request:
+#     branches:
+#       - 'main'
+#   push:
+#     branches:
+#       - 'CRAN*'
+on: push
 
 name: CRAN checks
 

--- a/.github/workflows/CRAN_check.yaml
+++ b/.github/workflows/CRAN_check.yaml
@@ -94,6 +94,7 @@ jobs:
         if: success() || failure()
         id: check-cran
         run: |
+          setwd("OlinkAnalyze")
           pkg <- read.dcf("DESCRIPTION")[, "Package"]
           on_cran <- pkg %in% rownames(available.packages(repos = "https://cran.r-project.org"))
           cat(sprintf("on_cran=%s\n", tolower(on_cran)), file = Sys.getenv("GITHUB_OUTPUT"), append = TRUE)

--- a/.github/workflows/CRAN_check.yaml
+++ b/.github/workflows/CRAN_check.yaml
@@ -89,6 +89,15 @@ jobs:
           devtools::check(remote = T, incoming = T, env_vars = c(NOT_CRAN = "false"))
         shell: Rscript {0}
         
+      - name: Check if package is on CRAN
+        if: success() || failure()
+        id: check-cran
+        run: |
+          pkg <- read.dcf("DESCRIPTION")[, "Package"]
+          on_cran <- pkg %in% rownames(available.packages(repos = "https://cran.r-project.org"))
+          cat(sprintf("on_cran=%s\n", tolower(on_cran)), file = Sys.getenv("GITHUB_OUTPUT"), append = TRUE)
+        shell: Rscript {0}
+        
       - name: revdep_check
         if: success() || failure()      
         run: |

--- a/.github/workflows/CRAN_check.yaml
+++ b/.github/workflows/CRAN_check.yaml
@@ -99,7 +99,7 @@ jobs:
         shell: Rscript {0}
         
       - name: revdep_check
-        if: success() || failure()      
+        if: (success() || failure()) && steps.check-cran.outputs.on_cran == 'true'
         run: |
           setwd("OlinkAnalyze")
         

--- a/.github/workflows/CRAN_check.yaml
+++ b/.github/workflows/CRAN_check.yaml
@@ -1,13 +1,12 @@
 # For help debugging build failures open an issue on the RStudio community with the 'github-actions' tag.
 # https://community.rstudio.com/new-topic?category=Package%20development&tags=github-actions
-# on:
-#   pull_request:
-#     branches:
-#       - 'main'
-#   push:
-#     branches:
-#       - 'CRAN*'
-on: push
+on:
+  pull_request:
+    branches:
+      - 'main'
+  push:
+    branches:
+      - 'CRAN*'
 
 name: CRAN checks
 


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for CRAN checks. The main changes focus on improving the handling of reverse dependency checks by first verifying if the package is on CRAN.

**Conditional reverse dependency checks:**
- Added a new step to check if the package is already on CRAN before running reverse dependency checks, and updated the `revdep_check` step to only run if the package is on CRAN.

**NOTE** "coverage-render-and-document" fail because of pathway enrichment updates. We can ignore this failure for now.