### PR TITLE
Fix bug in check_log column name retrieval

### DIFF
--- a/OlinkAnalyze/R/dist_plot.R
+++ b/OlinkAnalyze/R/dist_plot.R
@@ -126,7 +126,7 @@ olink_dist_plot <- function(df,
 
   # If QC selected to plot
   # If not all are Pass, the QC_Warning is set as warning for plotting purposes
-  if (color_g %in% column_name_dict$col_names$qc_warning) {
+  if (color_g %in% check_log$col_names$qc_warning) {
 
     df <- df |>
       dplyr::group_by(


### PR DESCRIPTION
***Note:** At this time we are unable to accept external contributions. For feature suggestions and any issues, please reach out to biostattools@olink.com.*

# Title: Write a very short summary here
**Problem:** In line 130 `if (color_g %in% column_name_dict$col_names$qc_warning)`, the `color_g` should select from `check_log$col_names$qc_wanring`.

**Solution:** Fix the bug.

**Key Features:**

* Key feature 1
* Key feature 2
* ...

## Checklist
- [x] Make sure you are requesting to **pull a feature/bugfix branch** (right side). This should not be main or develop.
- [x] Make sure you are make a pull request against either **main or develop** (left side). (Requesting to main should be reserved for bugfixes and new releases)
- [ ] Add or update unit tests (if applicable)
- [x] Check your code with any unit tests (Run devtools::check() locally)
- [ ] Add neccessary documentation (if applicable)

## Type of changes

What type of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue) (link the issue on the right)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Documentation Update 
- [ ] Other (explain)

## Further comments
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, any questions you have, etc...

Consider linking any issues (#issue-number ) or adding @mentions to ensure specific people see it.
