### PR TITLE
Add cheatsheet to DESCRIPTION and reference in vignette

### DIFF
--- a/OlinkAnalyze/DESCRIPTION
+++ b/OlinkAnalyze/DESCRIPTION
@@ -62,7 +62,10 @@ Description: A collection of functions to facilitate analysis of proteomic
     data run on the Olink platform.
 License: AGPL (>= 3)
 Contact: biostattools@olink.com
-URL: https://olink.com/ https://github.com/Olink-Proteomics/OlinkRPackage
+URL:
+    https://olink.com/
+    https://github.com/Olink-Proteomics/OlinkRPackage
+    https://7074596.fs1.hubspotusercontent-na1.net/hubfs/7074596/01-User%20Manuals%20for%20website/1494-Olink-Analyze-Cheatsheet.pdf
 Config/testthat/edition: 3
 Config/testthat/parallel: true
 Config/testthat/start-first: read_npx_l*, read_npx_w*

--- a/OlinkAnalyze/vignettes/OlinkAnalyze-Vignette.Rmd
+++ b/OlinkAnalyze/vignettes/OlinkAnalyze-Vignette.Rmd
@@ -50,7 +50,7 @@ install.packages("OlinkAnalyze")
 # List of functions
 
 *For a quick overview of the main functions and typical workflows, see the*
-*[OlinkAnalyze cheatsheet](https://7074596.fs1.hubspotusercontent-na1.net/hubfs/7074596/01-User%20Manuals%20for%20website/1494-Olink-Analyze-Cheatsheet.pdf).*
+*[Olink® Analyze R Package Cheatsheet](https://7074596.fs1.hubspotusercontent-na1.net/hubfs/7074596/01-User%20Manuals%20for%20website/1494-Olink-Analyze-Cheatsheet.pdf).*
 
 **Preprocessing**
 

--- a/OlinkAnalyze/vignettes/OlinkAnalyze-Vignette.Rmd
+++ b/OlinkAnalyze/vignettes/OlinkAnalyze-Vignette.Rmd
@@ -49,6 +49,9 @@ install.packages("OlinkAnalyze")
 
 # List of functions
 
+*For a quick overview of the main functions and typical workflows, see the*
+*[OlinkAnalyze cheatsheet](https://7074596.fs1.hubspotusercontent-na1.net/hubfs/7074596/01-User%20Manuals%20for%20website/1494-Olink-Analyze-Cheatsheet.pdf).*
+
 **Preprocessing**
 
 -   *read_npx* or *read_NPX* Function to read NPX data into long format


### PR DESCRIPTION
This pull request updates documentation for the OlinkAnalyze package by adding references to the official cheatsheet PDF in both the package metadata and the vignette. These changes make it easier for users to find an overview of the main functions and workflows.

Documentation updates:

* Added the URL for the OlinkAnalyze cheatsheet PDF to the `URL` field in the `DESCRIPTION` file, improving discoverability of official documentation.
* Included a direct link to the cheatsheet in the package vignette (`OlinkAnalyze-Vignette.Rmd`), guiding users to a quick overview of main functions and workflows.