### PR TITLE
Allow concatenation of OIDs

### DIFF
--- a/OlinkAnalyze/R/check_npx.R
+++ b/OlinkAnalyze/R/check_npx.R
@@ -767,7 +767,7 @@ check_npx_olinkid <- function(df,
     )  |>
     dplyr::filter(
       !grepl(
-        pattern = "^OID\\d{5}$",
+        pattern = "^OID\\d{5}$|^OID\\d{5}_OID\\d{5}$",
         x = .data[[col_names$olink_id]]
       )
     )  |>

--- a/OlinkAnalyze/tests/testthat/test-check_npx.R
+++ b/OlinkAnalyze/tests/testthat/test-check_npx.R
@@ -1086,6 +1086,34 @@ test_that(
   }
 )
 
+test_that(
+  "check_npx_olinkid - works - all OlinkID are valid - OID12345_OID54321",
+  {
+    df <- dplyr::tibble(
+      SampleID = c("A", "B", "C", "D"),
+      OlinkID = paste0(rep("OID12345", 4L), "_", rep("OID54321", 4L)),
+      UniProt = LETTERS[1L:4L],
+      Assay = LETTERS[1L:4L],
+      Panel = LETTERS[1L:4L],
+      Panel_Lot_Nr = LETTERS[1L:4L],
+      NPX = rnorm(4L),
+      PlateID = rep("plate1", 4L),
+      QC_Warning = rep("Pass", 4L)
+    )
+
+    expect_no_condition(
+      object = col_names <- check_npx_col_names(df = df,
+                                                preferred_names = NULL)
+    )
+
+    expect_equal(
+      object = check_npx_olinkid(df = df,
+                                 col_names = col_names),
+      expected = character(0L)
+    )
+  }
+)
+
 # Test check_npx_all_na_assays ----
 
 test_that(

--- a/OlinkAnalyze/tests/testthat/test-check_npx.R
+++ b/OlinkAnalyze/tests/testthat/test-check_npx.R
@@ -1114,6 +1114,45 @@ test_that(
   }
 )
 
+test_that(
+  "check_npx_olinkid - works - all OlinkID are valid - mixed",
+  {
+    df <- dplyr::tibble(
+      SampleID = c("A", "B", "C", "D"),
+      OlinkID = paste0(rep("OID12345", 4L), "_", rep("OID54321", 4L)),
+      UniProt = LETTERS[1L:4L],
+      Assay = LETTERS[1L:4L],
+      Panel = LETTERS[1L:4L],
+      Panel_Lot_Nr = LETTERS[1L:4L],
+      NPX = rnorm(4L),
+      PlateID = rep("plate1", 4L),
+      QC_Warning = rep("Pass", 4L)
+    ) |>
+      dplyr::mutate(
+        OlinkID = dplyr::if_else(
+          .data[["SampleID"]] %in% c("A", "B"),
+          stringr::str_split(
+            string = .data[["OlinkID"]],
+            pattern = "_",
+            simplify = TRUE
+          )[, 1L],
+          .data[["OlinkID"]]
+        )
+      )
+
+    expect_no_condition(
+      object = col_names <- check_npx_col_names(df = df,
+                                                preferred_names = NULL)
+    )
+
+    expect_equal(
+      object = check_npx_olinkid(df = df,
+                                 col_names = col_names),
+      expected = character(0L)
+    )
+  }
+)
+
 # Test check_npx_all_na_assays ----
 
 test_that(


### PR DESCRIPTION
This pull request expands the validation logic for OlinkID formats in the `check_npx_olinkid` function and adds a corresponding unit test to ensure the new format is accepted. The main changes are as follows:

**Validation logic update:**

* Updated the regular expression in `check_npx_olinkid` (in `OlinkAnalyze/R/check_npx.R`) to allow OlinkID values in the format `OID12345_OID54321` in addition to the original `OID12345` format.

**Testing improvements:**

* Added a new test in `OlinkAnalyze/tests/testthat/test-check_npx.R` to verify that the function accepts OlinkID values of the form `OID12345_OID54321` as valid.