### PR TITLE
Add release drafter configuration

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,62 @@
+# Name shown for the draft release
+name-template: "v$RESOLVED_VERSION"
+
+# Tag that will be suggested when the draft release is published
+tag-template: "v$RESOLVED_VERSION"
+
+# Group pull requests in the release notes based on their labels
+categories:
+  - title: "Features"
+    labels:
+      - "feature"
+      - "enhancement"
+
+  - title: "Bug fixes"
+    labels:
+      - "bug"
+      - "fix"
+      - "bugfix"
+
+  - title: "Documentation"
+    labels:
+      - "documentation"
+      - "docs"
+
+  - title: "Maintenance"
+    labels:
+      - "chore"
+      - "maintenance"
+      - "dependencies"
+
+# Format used for each pull request listed in the draft release notes
+change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
+
+# Escape characters that can otherwise interfere with Markdown rendering
+change-title-escapes: '\<*_&'
+
+# Decide the next version based on labels attached to merged pull requests
+version-resolver:
+  major:
+    labels:
+      - "major"
+  minor:
+    labels:
+      - "minor"
+      - "feature"
+      - "enhancement"
+  patch:
+    labels:
+      - "patch"
+      - "bug"
+      - "fix"
+      - "bugfix"
+      - "dependencies"
+
+  # Use a patch release if no version label is found
+  default: patch
+
+# Main body of the draft release notes
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -1,0 +1,24 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      # Update the draft release whenever changes land on the release branch
+      - main
+
+permissions:
+  # Required so Release Drafter can create or update draft GitHub releases
+  contents: write
+
+  # Required so Release Drafter can read merged pull requests and labels
+  pull-requests: read
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      # Creates or updates a draft release on the GitHub Releases page
+      - uses: release-drafter/release-drafter@v7
+        env:
+          # Built in token provided by GitHub Actions
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -19,6 +19,8 @@ jobs:
     steps:
       # Creates or updates a draft release on the GitHub Releases page
       - uses: release-drafter/release-drafter@v7
+        with:
+          config-name: release-drafter.yml # the default, loads '.github/release-drafter.yml'
         env:
           # Built in token provided by GitHub Actions
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request introduces Release Drafter to automate the creation and management of draft release notes whenever changes are pushed to the `main` branch. The configuration file defines how releases are named, how pull requests are grouped in release notes, and how version numbers are determined based on PR labels.

**Release automation setup:**

* Added `.github/workflows/release-drafter.yaml` to run Release Drafter on every push to `main`, automating the creation or update of draft releases using GitHub Actions.
* Added `.github/release-drafter.yml` to configure release note generation, including:
  - Naming and tagging conventions for releases.
  - Grouping of pull requests by labels into categories like Features, Bug fixes, Documentation, and Maintenance.
  - Custom formatting for each listed change in the release notes.
  - Automatic version bumping (major, minor, patch) based on PR labels, defaulting to patch if no label is present.

***Note:** Based on the upcoming release, and the results we will see from the drafter, we should make a few on how we can improve the drafter for the next release.*