### PR TITLE
Add version checks and warnings for dunn.test in Kruskal tests

### DIFF
--- a/OlinkAnalyze/R/Olink_one_non_parametric.R
+++ b/OlinkAnalyze/R/Olink_one_non_parametric.R
@@ -745,3 +745,26 @@ quiet_dunn <- function(formula, data, method = "bh") {
 
   return(out$res)
 }
+
+has_buggy_dunn_test <- function(is_installed = rlang::is_installed,
+                                package_version = utils::packageVersion) {
+  x <- is_installed("dunn.test") &&
+    package_version("dunn.test") == "1.4.0"
+  return(x)
+}
+
+warn_if_buggy_dunn_test <- function(has_buggy_version = has_buggy_dunn_test) {
+  if (has_buggy_version()) {
+    cli::cli_warn(
+      c(
+        "The installed version of {.pkg dunn.test} contains a known bug that
+        provides incorrect results!",
+        "i" = "Downgrade to v1.3.7 or upgrade to v1.4.1 using
+        {.run remotes::install_version(\"dunn.test\", version = \"1.3.7\")} or
+        {.run install.packages(\"dunn.test\")}, respectively."
+      )
+    )
+  }
+
+  return(invisible(NULL))
+}

--- a/OlinkAnalyze/R/Olink_one_non_parametric.R
+++ b/OlinkAnalyze/R/Olink_one_non_parametric.R
@@ -453,6 +453,10 @@ olink_one_non_parametric_posthoc <- function(df, # nolint object_length_linter
     )
   }
 
+  if (test == "kruskal") {
+    warn_if_buggy_dunn_test()
+  }
+
   # Check data format
   check_log <- run_check_npx(df = df, check_log = check_log)
 

--- a/OlinkAnalyze/tests/testthat/test-Olink_one_non_parametric.R
+++ b/OlinkAnalyze/tests/testthat/test-Olink_one_non_parametric.R
@@ -218,26 +218,56 @@ test_that(
     )
   }
 )
-      )
 
-      expect_equal(
-        object = nrow(kruskal_posthoc_results),
-        expected = 190
+test_that(
+  "olink_one_non_parametric_posthoc - warning - buggy dunn.test",
+  {
+    # has_buggy_dunn_test returns TRUE for dunn.test 1.4.0 ----
+    expect_true(
+      has_buggy_dunn_test(
+        is_installed = function(pkg) TRUE,
+        package_version = function(pkg) package_version("1.4.0")
       )
+    )
 
-      expect_equal(
-        object = kruskal_posthoc_results |>
-          dplyr::select(contrast) |>
-          unique() |>
-          nrow(),
-        expected = 10
+    # has_buggy_dunn_test returns FALSE when dunn.test is not installed ----
+    expect_false(
+      has_buggy_dunn_test(
+        is_installed = function(pkg) FALSE,
+        package_version = function(pkg) package_version("1.4.0")
       )
-    } else {
-      expect_snapshot(
-        kruskal_posthoc_results,
-        variant = "olink_one_non_parametric-kw-posthoc-dunn_test-1.4.0"
+    )
+
+    # has_buggy_dunn_test returns FALSE for dunn.test 1.3.7 ----
+    expect_false(
+      has_buggy_dunn_test(
+        is_installed = function(pkg) TRUE,
+        package_version = function(pkg) package_version("1.3.7")
       )
-    }
+    )
+
+    # has_buggy_dunn_test returns FALSE for dunn.test 1.4.1 ----
+    expect_false(
+      has_buggy_dunn_test(
+        is_installed = function(pkg) TRUE,
+        package_version = function(pkg) package_version("1.4.1")
+      )
+    )
+
+    # warn_if_buggy_dunn_test warns for dunn.test 1.4.0 ----
+    expect_warning(
+      warn_if_buggy_dunn_test(
+        has_buggy_version = function() TRUE
+      ),
+      regexp = "installed version of dunn\\.test contains a known bug"
+    )
+
+    # warn_if_buggy_dunn_test is silent for non-buggy dunn.test versions ----
+    expect_no_warning(
+      warn_if_buggy_dunn_test(
+        has_buggy_version = function() FALSE
+      )
+    )
   }
 )
 

--- a/OlinkAnalyze/tests/testthat/test-Olink_one_non_parametric.R
+++ b/OlinkAnalyze/tests/testthat/test-Olink_one_non_parametric.R
@@ -199,10 +199,25 @@ test_that(
       fixed = TRUE
     )
 
-    if (packageVersion("dunn.test") <= "1.3.7") {
-      expect_equal(
-        object = kruskal_posthoc_results,
-        expected = ref_results$kruskal_posthoc
+    expect_equal(
+      object = kruskal_posthoc_results,
+      expected = ref_results$kruskal_posthoc
+    )
+
+    expect_equal(
+      object = nrow(kruskal_posthoc_results),
+      expected = 190
+    )
+
+    expect_equal(
+      object = kruskal_posthoc_results |>
+        dplyr::select(contrast) |>
+        unique() |>
+        nrow(),
+      expected = 10
+    )
+  }
+)
       )
 
       expect_equal(

--- a/OlinkAnalyze/tests/testthat/test-Olink_one_non_parametric.R
+++ b/OlinkAnalyze/tests/testthat/test-Olink_one_non_parametric.R
@@ -116,6 +116,10 @@ test_that(
     skip_if_not_installed("FSA")
     skip_if_not_installed("broom")
     skip_if_not_installed("rstatix")
+    skip_if(
+      packageVersion("dunn.test") == "1.4.0",
+      "dunn.test version = 1.4.1 contains a bug."
+    )
 
     # npx_data1 check_log
     check_log <- check_npx(npx_data1) |>


### PR DESCRIPTION
This pull request introduces a warning system for a known bug in the `dunn.test` package (version 1.4.0) within the `Olink_one_non_parametric_posthoc` workflow. The main changes add detection and user notification for this buggy version, along with comprehensive tests to ensure the warning logic works as intended.

**Bug detection and user notification:**

* Added the `has_buggy_dunn_test` and `warn_if_buggy_dunn_test` helper functions to detect if the installed `dunn.test` package is version 1.4.0 and to warn users with clear upgrade/downgrade instructions if so. (`OlinkAnalyze/R/Olink_one_non_parametric.R`)
* Integrated the warning into the `olink_one_non_parametric_posthoc` function, so users are notified whenever the Kruskal-Wallis posthoc test is run with the buggy package version. (`OlinkAnalyze/R/Olink_one_non_parametric.R`)

**Testing improvements:**

* Updated and expanded tests to:
  - Skip tests if the buggy `dunn.test` version is present. (`OlinkAnalyze/tests/testthat/test-Olink_one_non_parametric.R`)
  - Remove outdated conditional logic for old versions. [[1]](diffhunk://#diff-c7380a47f62f582298a9d63fa194ea4256deb158b26a96e391ab17a3ab636e9fL198) [[2]](diffhunk://#diff-c7380a47f62f582298a9d63fa194ea4256deb158b26a96e391ab17a3ab636e9fL216-R270)
  - Add new tests for the bug detection and warning functions, ensuring correct behavior across different package versions.
