### PR TITLE
Improve logic on discerning between long and wide format files

### DIFF
--- a/OlinkAnalyze/R/read_npx_format.R
+++ b/OlinkAnalyze/R/read_npx_format.R
@@ -797,6 +797,21 @@ read_npx_format_get_quant <- function(file,
   check_file_exists(file = file,
                     error = TRUE)
 
+  if (all(is.na(data_cells))) {
+    cli::cli_abort(
+      message = c(
+        "x" = "Unable to recognize the quantification method from the input
+        file!",
+        "i" = "Cell 'A2' of the input file {.file {file}} in {.val {\"wide\"}}
+        format was likely empty. Expected one of:
+        {.val {get_olink_data_types(broad_platform = broad_platform)}}. Consider
+        setting {.arg data_type}."
+      ),
+      call = rlang::caller_env(),
+      wrap = FALSE
+    )
+  }
+
   check_is_character(x = data_cells,
                      error = TRUE)
 

--- a/OlinkAnalyze/R/read_npx_format.R
+++ b/OlinkAnalyze/R/read_npx_format.R
@@ -789,6 +789,9 @@ read_npx_format_get_quant <- function(file,
                                       data_type = NULL,
                                       data_cells) {
 
+  # help vars
+  broad_platform <- "qPCR"
+
   # Checks inputs ----
 
   check_file_exists(file = file,
@@ -796,9 +799,6 @@ read_npx_format_get_quant <- function(file,
 
   check_is_character(x = data_cells,
                      error = TRUE)
-
-  # help vars
-  broad_platform <- "qPCR"
 
   # check data type
   if (!is.null(data_type)) {

--- a/OlinkAnalyze/R/read_npx_format.R
+++ b/OlinkAnalyze/R/read_npx_format.R
@@ -432,9 +432,13 @@ read_npx_format_get_format <- function(df_top_n,
     ) |>
     # convert to character to simplify operations below
     as.character() |>
-    # exclude column NPX Signature Version as it results in the function not
-    # recognizing the format
-    (\(.x) .x[!grepl(pattern = "Version", x = .x, ignore.case = TRUE)])()
+    # exclude columns:
+    # "NPX Signature Version"
+    # "Olink NPX Signature X.Y.Z.M"
+    # as they result in the function not recognizing the format
+    (\(.x) .x[!grepl(pattern = "Version|Signature",
+                     x = .x,
+                     ignore.case = TRUE)])()
 
   # Determine long or wide format from file ----
 

--- a/OlinkAnalyze/R/read_npx_format.R
+++ b/OlinkAnalyze/R/read_npx_format.R
@@ -442,9 +442,11 @@ read_npx_format_get_format <- function(df_top_n,
 
   # Determine long or wide format from file ----
 
+  # data is wide when the quant method is found in cell A2 or the length of
+  # non-NA columns in the first row is exactly 2.
   is_data_wide <- grepl(pattern = paste(get_olink_data_types(), collapse = "|"),
                         x = data_cells_wide,
-                        ignore.case = FALSE)
+                        ignore.case = FALSE) | data_cells_len == 2L
   is_data_long <- grepl(pattern = paste(get_olink_data_types(), collapse = "|"),
                         x = data_cells_long,
                         ignore.case = FALSE) |>

--- a/OlinkAnalyze/R/read_npx_format.R
+++ b/OlinkAnalyze/R/read_npx_format.R
@@ -433,7 +433,8 @@ read_npx_format_get_format <- function(df_top_n,
                         ignore.case = FALSE)
   is_data_long <- grepl(pattern = paste(get_olink_data_types(), collapse = "|"),
                         x = data_cells_long,
-                        ignore.case = FALSE)
+                        ignore.case = FALSE) |>
+    any()
 
   if (is_data_wide == TRUE) {
     # in wide format files we expect the quantification method to appear in
@@ -442,7 +443,7 @@ read_npx_format_get_format <- function(df_top_n,
     detected_long_format <- FALSE
     data_cells <- data_cells_wide
 
-  } else if (is_data_wide == FALSE && any(is_data_long == TRUE)) {
+  } else if (is_data_wide == FALSE && is_data_long == TRUE) {
     # in long format files we expect the quantification method to appear in
     # cells L1:O1 and we also expect no matches to cell A2. This is what marks
     # wide format files.

--- a/OlinkAnalyze/R/read_npx_format.R
+++ b/OlinkAnalyze/R/read_npx_format.R
@@ -416,6 +416,16 @@ read_npx_format_get_format <- function(df_top_n,
     # convert to character to simplify operations below
     as.character()
 
+  data_cells_len <- df_top_n |>
+    dplyr::slice_head(
+      n = 1L
+    ) |>
+    # convert to character to simplify operations below
+    as.character() |>
+    # remove NA values and count the number of non-NA columns
+    (\(.x) .x[!is.na(.x)])() |>
+    length()
+
   data_cells_long <- df_top_n |>
     dplyr::slice_head(
       n = 1L

--- a/OlinkAnalyze/R/read_npx_format.R
+++ b/OlinkAnalyze/R/read_npx_format.R
@@ -797,28 +797,28 @@ read_npx_format_get_quant <- function(file,
   check_file_exists(file = file,
                     error = TRUE)
 
-  if (all(is.na(data_cells))) {
-    cli::cli_abort(
-      message = c(
-        "x" = "Unable to recognize the quantification method from the input
-        file!",
-        "i" = "Cell 'A2' of the input file {.file {file}} in {.val {\"wide\"}}
-        format was likely empty. Expected one of:
-        {.val {get_olink_data_types(broad_platform = broad_platform)}}. Consider
-        setting {.arg data_type}."
-      ),
-      call = rlang::caller_env(),
-      wrap = FALSE
-    )
-  }
-
-  check_is_character(x = data_cells,
-                     error = TRUE)
-
   # check data type
   if (!is.null(data_type)) {
     check_olink_data_type(x = data_type,
                           broad_platform = broad_platform)
+  } else {
+    if (all(is.na(data_cells))) {
+      cli::cli_abort(
+        message = c(
+          "x" = "Unable to recognize the quantification method from the input
+        file!",
+          "i" = "Cell 'A2' of the input file {.file {file}} in {.val {\"wide\"}}
+        format was likely empty. Expected one of:
+        {.val {get_olink_data_types(broad_platform = broad_platform)}}. Consider
+        setting {.arg data_type}."
+        ),
+        call = rlang::caller_env(),
+        wrap = FALSE
+      )
+    } else {
+      check_is_character(x = data_cells,
+                         error = TRUE)
+    }
   }
 
   # Determine quantification method from excel file ----

--- a/OlinkAnalyze/R/read_npx_format.R
+++ b/OlinkAnalyze/R/read_npx_format.R
@@ -436,9 +436,7 @@ read_npx_format_get_format <- function(df_top_n,
     # "NPX Signature Version"
     # "Olink NPX Signature X.Y.Z.M"
     # as they result in the function not recognizing the format
-    (\(.x) .x[!grepl(pattern = "Version|Signature",
-                     x = .x,
-                     ignore.case = TRUE)])()
+    (\(.x) .x[!grepl(pattern = "Version|Signature", x = .x, ignore.case = TRUE)])() # nolint: line_length_linter
 
   # Determine long or wide format from file ----
 

--- a/OlinkAnalyze/R/read_npx_format.R
+++ b/OlinkAnalyze/R/read_npx_format.R
@@ -451,6 +451,7 @@ read_npx_format_get_format <- function(df_top_n,
                         x = data_cells_long,
                         ignore.case = FALSE) |>
     any()
+  is_data_long <- is_data_long & data_cells_len > 2L
 
   if (is_data_wide == TRUE) {
     # in wide format files we expect the quantification method to appear in

--- a/OlinkAnalyze/R/read_npx_wide.R
+++ b/OlinkAnalyze/R/read_npx_wide.R
@@ -267,6 +267,10 @@ read_npx_wide_split_row <- function(df,
     # filter rows with all cols NA
     dplyr::filter(
       .data[["num_na"]] == .data[["total_col"]]
+    ) |>
+    # ignore the first two rows which we expect to be the header matrix
+    dplyr::filter(
+      .data[["row_number"]] > 2L
     )
 
   if (nrow(na_row_index) > 0L) {

--- a/OlinkAnalyze/tests/testthat/test-olink_pathway_enrichment.R
+++ b/OlinkAnalyze/tests/testthat/test-olink_pathway_enrichment.R
@@ -420,7 +420,7 @@ test_that(
 
     expect_equal(
       object = dim(tt_ora),
-      expected = c(573L, 12L)
+      expected = c(345L, 12L)
     )
   }
 )
@@ -469,7 +469,7 @@ test_that(
 
     expect_equal(
       object = dim(tt_ora_reactome),
-      expected = c(20L, 12L)
+      expected = c(15L, 12L)
     )
   }
 )
@@ -572,7 +572,7 @@ test_that(
 
     expect_equal(
       object = dim(tt_ora_go),
-      expected = c(356L, 12L)
+      expected = c(212L, 12L)
     )
   }
 )

--- a/OlinkAnalyze/tests/testthat/test-read_npx_format.R
+++ b/OlinkAnalyze/tests/testthat/test-read_npx_format.R
@@ -3405,3 +3405,41 @@ test_that(
     )
   }
 )
+
+test_that(
+  "read_npx_format_get_quant - error - empty cell A2 in wide file",
+  {
+    withr::with_tempfile(
+      new = "excel_wide",
+      pattern = "test_excel_wide",
+      fileext = ".xlsx",
+      code = {
+        # writing something to the file
+        writeLines("foo", excel_wide)
+
+        # check that file exists
+        expect_true(object = file.exists(excel_wide))
+
+        # check that read_npx_format_get_quant works for data_type = NULL
+        expect_error(
+          object = read_npx_format_get_quant(
+            file = excel_wide,
+            data_type = NULL,
+            data_cells = NA_character_
+          ),
+          regexp = "Cell 'A2' of the input file"
+        )
+
+        # check that read_npx_format_get_quant works for data_type = NULL
+        expect_error(
+          object = read_npx_format_get_quant(
+            file = excel_wide,
+            data_type = NULL,
+            data_cells = c(NA_character_, NA_real_, NA)
+          ),
+          regexp = "Cell 'A2' of the input file"
+        )
+      }
+    )
+  }
+)

--- a/OlinkAnalyze/tests/testthat/test-read_npx_format.R
+++ b/OlinkAnalyze/tests/testthat/test-read_npx_format.R
@@ -2300,7 +2300,8 @@ test_that(
           dplyr::mutate(
             V1 = dplyr::if_else(.data[["V1"]] == "NPX",
                                 "Wrong_Name",
-                                .data[["V1"]])
+                                .data[["V1"]]),
+            V2 = dplyr::if_else(dplyr::row_number() == 1L, NA, .data[["V2"]])
           )
 
         # write a dummy file
@@ -2421,7 +2422,8 @@ test_that(
           dplyr::mutate(
             V1 = dplyr::if_else(.data[["V1"]] == "NPX",
                                 "Wrong_Name",
-                                .data[["V1"]])
+                                .data[["V1"]]),
+            V2 = dplyr::if_else(dplyr::row_number() == 1L, NA, .data[["V2"]])
           )
 
         # write a dummy file
@@ -2523,7 +2525,8 @@ test_that(
           dplyr::mutate(
             V1 = dplyr::if_else(.data[["V1"]] == "NPX",
                                 "Wrong_Name",
-                                .data[["V1"]])
+                                .data[["V1"]]),
+            V2 = dplyr::if_else(dplyr::row_number() == 1L, NA, .data[["V2"]])
           )
 
         # write a dummy file

--- a/OlinkAnalyze/tests/testthat/test-read_npx_format.R
+++ b/OlinkAnalyze/tests/testthat/test-read_npx_format.R
@@ -1445,7 +1445,7 @@ test_that(
 ## Special cases ----
 
 test_that(
-  "read_npx_format - error - wide - cell A2 is empty",
+  "read_npx_format - wide - cell A2 is empty",
   {
     skip_if_not_installed("writexl")
 
@@ -1463,7 +1463,7 @@ test_that(
       version = 2L
     )
 
-    ## excel ----
+    ## excel  - data_type = NULL ----
 
     withr::with_tempfile(
       new = "excel_wide",
@@ -1497,6 +1497,50 @@ test_that(
             quiet = FALSE
           ),
           regexp = "Cell 'A2' of the input file.*format was likely empty"
+        )
+      }
+    )
+
+    ## excel  - data_type = "NPX" ----
+
+    withr::with_tempfile(
+      new = "excel_wide",
+      pattern = "test_wide",
+      fileext = ".xlsx",
+      code = {
+        df_rand$list_df_wide$df_wide <- df_rand$list_df_wide$df_wide |>
+          dplyr::mutate(
+            V1 = dplyr::if_else(
+              dplyr::row_number() == 2L, NA_character_, .data[["V1"]]
+            )
+          )
+
+        # write in csv
+        writexl::write_xlsx(x = df_rand$list_df_wide$df_wide,
+                            path = excel_wide,
+                            col_names = FALSE,
+                            format_headers = FALSE)
+
+        #check that file exists
+        expect_true(object = file.exists(excel_wide))
+
+        # check that read_npx_format works
+        expect_no_error(
+          object = expect_message(
+            object = expect_warning(
+              object = df_out_v1 <- read_npx_format(
+                file = excel_wide,
+                out_df = "tibble",
+                long_format = NULL,
+                olink_platform = NULL,
+                data_type = "NPX",
+                quiet = FALSE
+              ),
+              regexp = "Unable to recognize the quantification method from the"
+            ),
+            regexp = paste("Detected \"NPX\" data from \"Olink Target 48\" in",
+                           "wide format!")
+          )
         )
       }
     )

--- a/OlinkAnalyze/tests/testthat/test-read_npx_format.R
+++ b/OlinkAnalyze/tests/testthat/test-read_npx_format.R
@@ -1893,6 +1893,93 @@ test_that(
 )
 
 test_that(
+  "read_npx_format_get_format - works - wide - Cell 'A2' is NA",
+  {
+    # get synthetic data, or skip if not available
+    df_rand <- get_wide_synthetic_data(
+      olink_platform = "Target 48",
+      data_type = "NPX",
+      n_panels = 3L,
+      n_assays = 45L,
+      n_samples = 88L,
+      show_dev_int_ctrl = FALSE,
+      show_int_ctrl = TRUE,
+      version = 1L
+    )
+
+    withr::with_tempfile(
+      new = "excel_wide",
+      pattern = "test_excel_npx_wide",
+      fileext = ".xlsx",
+      code = {
+        # modify df wide
+        df <- df_rand$list_df_wide$df_wide |>
+          dplyr::slice_head(
+            n = 2L
+          ) |>
+          # creating special cases when cell A2 is NA
+          dplyr::mutate(
+            V1 = dplyr::if_else(dplyr::row_number() == 2L, NA, .data[["V1"]])
+          )
+
+        # write a dummy file
+        writeLines("foo", excel_wide)
+
+        #check that file exists
+        expect_true(object = file.exists(excel_wide))
+
+        # check that read_npx_format_get_format works with long_format = NULL
+        expect_no_condition(
+          object = df_npx_null <- read_npx_format_get_format(
+            df_top_n = df,
+            file = excel_wide,
+            long_format = NULL
+          )
+        )
+
+        # check that object exists
+        expect_true(object = exists("df_npx_null"))
+
+        # check that it contains the correct elements
+        expect_equal(
+          object = names(df_npx_null),
+          expected = c("is_long_format", "data_cells")
+        )
+
+        # check that it is the correct format
+        expect_equal(
+          object = df_npx_null$is_long_format,
+          expected = FALSE
+        )
+
+        # check that the output string is correct
+        expect_true(
+          object = is.na(df_npx_null$data_cells)
+        )
+
+        # check that read_npx_format_get_format works with long_format = FALSE
+        expect_no_condition(
+          object = df_npx_false <- read_npx_format_get_format(
+            df_top_n = df,
+            file = excel_wide,
+            long_format = FALSE
+          )
+        )
+
+        # check that object exists
+        expect_true(object = exists("df_npx_false"))
+
+        # check that the two runs of read_npx_format_get_format return the same
+        expect_identical(
+          object = df_npx_false,
+          expected = df_npx_null
+        )
+      }
+    )
+  }
+)
+
+test_that(
   "read_npx_format_get_format - works - long",
   {
     # get synthetic data, or skip if not available

--- a/OlinkAnalyze/tests/testthat/test-read_npx_format.R
+++ b/OlinkAnalyze/tests/testthat/test-read_npx_format.R
@@ -1442,6 +1442,68 @@ test_that(
   }
 )
 
+## Special cases ----
+
+test_that(
+  "read_npx_format - error - wide - cell A2 is empty",
+  {
+    skip_if_not_installed("writexl")
+
+    ## current version ----
+
+    # get synthetic data, or skip if not available
+    df_rand <- get_wide_synthetic_data(
+      olink_platform = "Target 48",
+      data_type = "NPX",
+      n_panels = 3L,
+      n_assays = 45L,
+      n_samples = 99L,
+      show_dev_int_ctrl = TRUE,
+      show_int_ctrl = TRUE,
+      version = 2L
+    )
+
+    ## excel ----
+
+    withr::with_tempfile(
+      new = "excel_wide",
+      pattern = "test_wide",
+      fileext = ".xlsx",
+      code = {
+        df_rand$list_df_wide$df_wide <- df_rand$list_df_wide$df_wide |>
+          dplyr::mutate(
+            V1 = dplyr::if_else(
+              dplyr::row_number() == 2L, NA_character_, .data[["V1"]]
+            )
+          )
+
+        # write in csv
+        writexl::write_xlsx(x = df_rand$list_df_wide$df_wide,
+                            path = excel_wide,
+                            col_names = FALSE,
+                            format_headers = FALSE)
+
+        #check that file exists
+        expect_true(object = file.exists(excel_wide))
+
+        # check that read_npx_format works
+        expect_error(
+          object = df_out_v1 <- read_npx_format(
+            file = excel_wide,
+            out_df = "tibble",
+            long_format = NULL,
+            olink_platform = NULL,
+            data_type = NULL,
+            quiet = FALSE
+          ),
+          regexp = "Cell 'A2' of the input file.*format was likely empty"
+        )
+      }
+    )
+
+  }
+)
+
 # Test read_npx_format_read ----
 
 test_that(

--- a/OlinkAnalyze/tests/testthat/test-read_npx_wide.R
+++ b/OlinkAnalyze/tests/testthat/test-read_npx_wide.R
@@ -203,6 +203,86 @@ test_that(
         )
       }
     )
+
+    ## NPX - special case when A2 is empty ----
+
+    # synthetic wide df
+    data_type <- "NPX"
+    show_dev_int_ctrl <- TRUE
+    version <- 1L
+
+    # get synthetic data, or skip if not available
+    df_rand <- get_wide_synthetic_data(
+      olink_platform = olink_platform,
+      data_type = data_type,
+      n_panels = n_panels,
+      n_assays = n_assays,
+      n_samples = n_samples,
+      show_dev_int_ctrl = show_dev_int_ctrl,
+      show_int_ctrl = show_int_ctrl,
+      version = version
+    )
+
+    withr::with_tempfile(
+      new = "olink_wide_format",
+      pattern = "test-olink-wide",
+      fileext = ".xlsx",
+      code = {
+        df_rand$list_df_wide$df_wide <- df_rand$list_df_wide$df_wide |>
+          dplyr::mutate(
+            V1 = dplyr::if_else(
+              .data[["V1"]] == .env[["data_type"]], NA_character_, .data[["V1"]]
+            )
+          )
+
+        # write wide df
+        writeLines("foo", olink_wide_format)
+
+        # check that function runs
+        expect_no_error(
+          expect_no_warning(
+            object = df_out <- read_npx_wide_split_row(
+              df = df_rand$list_df_wide$df_wide,
+              file = olink_wide_format,
+              data_type = data_type,
+              format_spec = get_format_spec(data_type = data_type)
+            )
+          )
+        )
+
+        # check that df_head works
+        expect_identical(
+          object = remove_all_na_cols(df = df_out$df_head),
+          expected = df_rand$list_df_wide$df_head_wide |>
+            dplyr::mutate(
+              V1 = dplyr::if_else(
+                .data[["V1"]] == .env[["data_type"]],
+                NA_character_,
+                .data[["V1"]]
+              )
+            )
+        )
+
+        # check that df_top works
+        expect_identical(
+          object = df_out$df_top,
+          expected = df_rand$list_df_wide$df_top_wide
+        )
+
+        # check that df_mid works
+        expect_identical(
+          object = df_out$df_mid,
+          expected = df_rand$list_df_wide$df_middle_wide
+        )
+
+        # check that df_bottom works
+        expect_identical(
+          object = remove_all_na_cols(df = df_out$df_bottom),
+          expected = df_rand$list_df_wide$df_bottom_wide
+        )
+
+      }
+    )
   }
 )
 
@@ -744,10 +824,16 @@ test_that(
       code = {
         # modify and write wide df
         df_rand$list_df_wide$df_wide <- df_rand$list_df_wide$df_wide |>
+          # all columns in row 15 should be NA
           dplyr::mutate(
-            V1 = dplyr::if_else(.data[["V1"]] == .env[["data_type"]],
-                                NA_character_,
-                                .data[["V1"]])
+            dplyr::across(
+              .cols = dplyr::everything(),
+              .fns = ~ dplyr::if_else(
+                dplyr::row_number() == 15L,
+                NA_character_,
+                .x
+              )
+            )
           )
 
         # write wide df
@@ -757,6 +843,58 @@ test_that(
         expect_error(
           object = read_npx_wide_split_row(
             df = df_rand$list_df_wide$df_wide,
+            file = olink_wide_format,
+            data_type = data_type,
+            format_spec = format_spec
+          ),
+          regexp = "We identified 3 rows with all columns `NA` in file"
+        )
+      }
+    )
+
+    ## Too many all-NA rows - special case when A2 is empty ----
+
+    # A2 is empty and its next row is also empty
+
+    withr::with_tempfile(
+      new = "olink_wide_format",
+      pattern = "test-olink-wide",
+      fileext = ".xlsx",
+      code = {
+        # modify and write wide df
+        df_rand_tmp <- df_rand$list_df_wide$df_head_wide |>
+          dplyr::slice_head(
+            n = 1L
+          ) |>
+          dplyr::bind_rows(
+            df_rand$list_df_wide$df_na_wide
+          ) |>
+          dplyr::bind_rows(
+            df_rand$list_df_wide$df_na_wide
+          ) |>
+          dplyr::bind_rows(
+            df_rand$list_df_wide$df_top_wide
+          ) |>
+          dplyr::bind_rows(
+            df_rand$list_df_wide$df_na_wide
+          ) |>
+          dplyr::bind_rows(
+            df_rand$list_df_wide$df_middle_wide
+          ) |>
+          dplyr::bind_rows(
+            df_rand$list_df_wide$df_na_wide
+          ) |>
+          dplyr::bind_rows(
+            df_rand$list_df_wide$df_bottom_wide
+          )
+
+        # write wide df
+        writeLines("foo", olink_wide_format)
+
+        # check that function runs with error
+        expect_error(
+          object = read_npx_wide_split_row(
+            df = df_rand_tmp,
             file = olink_wide_format,
             data_type = data_type,
             format_spec = format_spec


### PR DESCRIPTION
***Note:** At this time we are unable to accept external contributions. For feature suggestions and any issues, please reach out to biostattools@olink.com.*

# Title: Improve logic on discerning between long and wide format files
**Problem:** In wide formatted files, when cell A2 was empty we would falsely identify file as long formatted, and misleading error would appear.

**Solution:** This pull request improves the robustness and error handling of the NPX file reading functions, particularly for edge cases where key cells (such as cell A2) are empty or contain unexpected values. It also updates and extends the test suite to cover these scenarios to reflect changes in test data or logic.

**Key Features:**

* Improved detection logic in `read_npx_format_get_format` to better handle cases where cell A2 is empty or NA, including updating the criteria for determining wide vs. long format and handling special cases for columns with "Version" or "Signature" in their names. [[1]](diffhunk://#diff-ce758d7eb7894c5844945e88628df9f2053914f8eb6a10cf7ba7375a0d73f46bR419-R452) [[2]](diffhunk://#diff-ce758d7eb7894c5844945e88628df9f2053914f8eb6a10cf7ba7375a0d73f46bL445-R461)
* Enhanced error handling in `read_npx_format_get_quant` to provide a clear error message when cell A2 is empty, guiding the user to set the `data_type` parameter if automatic detection fails.
* Added new tests for edge cases, such as when cell A2 is empty in wide-format files, ensuring that errors are thrown as expected and that format detection functions handle these cases gracefully. [[1]](diffhunk://#diff-b07cced680be4b87d7406a20eab3b035ad1427f95914c82557013d25be70e344R1445-R1506) [[2]](diffhunk://#diff-b07cced680be4b87d7406a20eab3b035ad1427f95914c82557013d25be70e344R1957-R2043) [[3]](diffhunk://#diff-b07cced680be4b87d7406a20eab3b035ad1427f95914c82557013d25be70e344R3470-R3507)
* Added and updated tests to check behavior when certain cells are set to NA, including modifications to synthetic test data to simulate these scenarios. [[1]](diffhunk://#diff-b07cced680be4b87d7406a20eab3b035ad1427f95914c82557013d25be70e344L2216-R2366) [[2]](diffhunk://#diff-b07cced680be4b87d7406a20eab3b035ad1427f95914c82557013d25be70e344L2337-R2488) [[3]](diffhunk://#diff-b07cced680be4b87d7406a20eab3b035ad1427f95914c82557013d25be70e344L2439-R2591)

## Checklist
- [X] Make sure you are requesting to **pull a feature/bugfix branch** (right side). This should not be main or develop.
- [X] Make sure you are make a pull request against either **main or develop** (left side). (Requesting to main should be reserved for bugfixes and new releases)
- [X] Add or update unit tests (if applicable)
- [X] Check your code with any unit tests (Run devtools::check() locally)
- [ ] Add neccessary documentation (if applicable)

## Type of changes

What type of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue) (link the issue on the right)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Documentation Update 
- [ ] Other (explain)

## Further comments

We had to update some tests from the pathway enrichment as they were failing because of package updates:
* Adjusted expected output dimensions in pathway enrichment tests to reflect changes in the underlying test data or logic, ensuring tests remain accurate and up to date. [[1]](diffhunk://#diff-bc6ff0474e7cafee4533d7fc14744712709bf8eb89a7e36dec117ca40933d16eL423-R423) [[2]](diffhunk://#diff-bc6ff0474e7cafee4533d7fc14744712709bf8eb89a7e36dec117ca40933d16eL472-R472) [[3]](diffhunk://#diff-bc6ff0474e7cafee4533d7fc14744712709bf8eb89a7e36dec117ca40933d16eL575-R575)
