### PR TITLE
Fix grammar of error message

### DIFF
--- a/OlinkAnalyze/R/check_columns.R
+++ b/OlinkAnalyze/R/check_columns.R
@@ -180,7 +180,7 @@ check_log_colname <- function(check_log, col_key) {
       c(
         "x" = "Input dataset lacks a column matching to the key
         {.val {col_key}}!",
-        "i" = "Please make sure that the it contains a column named:
+        "i" = "Please make sure that it contains a column named:
         {.or {.val {get_alt_colnames(col_key = col_key)}}}."
 
       ),


### PR DESCRIPTION
This pull request makes a minor correction to the user-facing message in the `check_log_colname` function. The change fixes a grammatical error in the information message to improve clarity.
