### PR TITLE
Improve error message clarity for cells A1 and B1

### DIFF
--- a/OlinkAnalyze/R/read_npx_utils.R
+++ b/OlinkAnalyze/R/read_npx_utils.R
@@ -37,9 +37,9 @@ read_npx_format_colnames <- function(df,
 
       cli::cli_abort( # nolint: return_linter
         message = c(
-          "x" = "Unexpected first row in file {.file {file}}!",
-          "i" = "Detected file in wide format. Expected only cells in A1 and B1
-          to be populated."
+          "x" = "Unexpected first row in wide format file {.file {file}}!",
+          "i" = "Expected only cells A1 and B1 to be populated with the string
+          \"Project Name\" and the name of the current project, respectively."
         ),
         call = rlang::caller_env(),
         wrap = FALSE

--- a/OlinkAnalyze/tests/testthat/test-read_npx_utils.R
+++ b/OlinkAnalyze/tests/testthat/test-read_npx_utils.R
@@ -45,13 +45,17 @@ test_that(
         expect_error(
           object = read_npx_format_colnames(df = df,
                                             file = cdfile_test),
-          regexp = "Detected file in wide format"
+          regexp = paste("Expected only cells A1 and B1 to be populated with",
+                         "the string \"Project Name\" and the name of the",
+                         "current project, respectively.")
         )
 
         expect_error(
           object = read_npx_format_colnames(df = arrow::as_arrow_table(df),
                                             file = cdfile_test),
-          regexp = "Detected file in wide format"
+          regexp = paste("Expected only cells A1 and B1 to be populated with",
+                         "the string \"Project Name\" and the name of the",
+                         "current project, respectively.")
         )
       }
     )


### PR DESCRIPTION
This pull request updates the error messaging for wide format file validation in the `read_npx_format_colnames` function and its associated tests. The new messages provide clearer guidance on the expected file structure.

**Error message improvements:**

* Updated the error message in `read_npx_format_colnames` (in `OlinkAnalyze/R/read_npx_utils.R`) to specify that only cells A1 and B1 should be populated with "Project Name" and the current project name, respectively.

**Test updates:**

* Updated the corresponding tests in `test-read_npx_utils.R` to check for the new, more descriptive error message.