### PR TITLE
Replace legacy `.Dim` with `dim`

### DIFF
--- a/OlinkAnalyze/tests/testthat/test-olink_color.R
+++ b/OlinkAnalyze/tests/testthat/test-olink_color.R
@@ -13,7 +13,7 @@ test_that(
       )(n = 2L),
       expected = structure(
         c("#077183FF", "#FF51B8FF"),
-        dim = 2:1
+        dim = 2L:1L
       )
     )
 

--- a/OlinkAnalyze/tests/testthat/test-olink_color.R
+++ b/OlinkAnalyze/tests/testthat/test-olink_color.R
@@ -13,7 +13,7 @@ test_that(
       )(n = 2L),
       expected = structure(
         c("#077183FF", "#FF51B8FF"),
-        .Dim = 2:1
+        dim = 2:1
       )
     )
 


### PR DESCRIPTION
This pull request makes a minor change to the `test-olink_color.R` test file, updating the way the expected result's dimensions are specified to use the `dim` argument instead of `.Dim`. The legacy argument was causing a `NOTE` on CRAN check for OlinkAnalyze.

**Note:** This code should be tested using `rhub`.